### PR TITLE
Redesign: terminal/IDE-inspired portfolio with warm coffee tones

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import { Manrope, Inter } from "next/font/google";
+import { Inter, JetBrains_Mono, Instrument_Serif } from "next/font/google";
 import { notFound } from "next/navigation";
 import { hasLocale } from "next-intl";
 import { NextIntlClientProvider } from "next-intl";
@@ -6,16 +6,23 @@ import { getMessages, setRequestLocale } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import "../globals.css";
 
-const manrope = Manrope({
-  variable: "--font-manrope",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700", "800"],
+  weight: ["300", "400", "500", "600", "700"],
+});
+
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-instrument",
+  subsets: ["latin"],
+  weight: ["400"],
+  style: ["normal", "italic"],
 });
 
 const inter = Inter({
   variable: "--font-inter",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["300", "400", "500", "600", "700"],
 });
 
 export function generateStaticParams() {
@@ -54,9 +61,7 @@ export async function generateMetadata({
     creator: "Juan Murillo",
     metadataBase: new URL("https://juanmurillo.co"),
     icons: {
-      icon: [
-        { url: "/icon.svg", type: "image/svg+xml" },
-      ],
+      icon: [{ url: "/icon.svg", type: "image/svg+xml" }],
       apple: "/icon.svg",
     },
     robots: {
@@ -122,7 +127,7 @@ export default async function LocaleLayout({
   return (
     <html
       lang={locale}
-      className={`${manrope.variable} ${inter.variable} h-full antialiased`}
+      className={`${jetbrainsMono.variable} ${instrumentSerif.variable} ${inter.variable} h-full antialiased`}
     >
       <head>
         <link
@@ -141,7 +146,7 @@ export default async function LocaleLayout({
           href="https://juanmurillo.co/en"
         />
       </head>
-      <body className="min-h-full flex flex-col bg-background text-foreground">
+      <body className="grain min-h-full flex flex-col">
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { setRequestLocale } from "next-intl/server";
+import StatusBar from "@/components/StatusBar";
 import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
 import FeaturedWork from "@/components/FeaturedWork";
@@ -8,6 +9,7 @@ import Lately from "@/components/Lately";
 import About from "@/components/About";
 import Contact from "@/components/Contact";
 import Footer from "@/components/Footer";
+import CommandPalette from "@/components/CommandPalette";
 
 export default async function Home({
   params,
@@ -19,8 +21,9 @@ export default async function Home({
 
   return (
     <>
+      <StatusBar />
       <Navbar />
-      <main>
+      <main className="pt-[90px]">
         <Hero />
         <FeaturedWork />
         <Services />
@@ -30,6 +33,7 @@ export default async function Home({
         <Contact />
       </main>
       <Footer />
+      <CommandPalette />
     </>
   );
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -10,6 +10,7 @@ import About from "@/components/About";
 import Contact from "@/components/Contact";
 import Footer from "@/components/Footer";
 import CommandPalette from "@/components/CommandPalette";
+import CopyMarkdown from "@/components/CopyMarkdown";
 
 export default async function Home({
   params,
@@ -33,6 +34,7 @@ export default async function Home({
         <Contact />
       </main>
       <Footer />
+      <CopyMarkdown />
       <CommandPalette />
     </>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,6 +86,18 @@ em {
 /* Pulse animation */
 @keyframes pulse { 50% { opacity: 0.4; } }
 
+/* ============ Content wrapper ============ */
+.wrap {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+@media (max-width: 640px) {
+  .wrap {
+    padding: 0 18px;
+  }
+}
+
 /* ============ Hero responsive ============ */
 .hero-grid {
   display: grid;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,164 +1,79 @@
 @import "tailwindcss";
 
 :root {
-  --background: #0b0e14;
-  --foreground: #ecedf6;
-  --surface: #0b0e14;
-  --surface-container-low: #10131a;
-  --surface-container: #161a21;
-  --surface-container-high: #1c2028;
-  --surface-container-highest: #22262f;
-  --surface-bright: #282c36;
-  --surface-variant: #22262f;
-  --primary: #aca3ff;
-  --primary-dim: #6f5fea;
-  --primary-container: #9e93ff;
-  --secondary: #00d2ff;
-  --secondary-dim: #00c3ed;
-  --secondary-container: #00677f;
-  --tertiary: #b0aaff;
-  --on-surface: #ecedf6;
-  --on-surface-variant: #a9abb3;
-  --outline: #73757d;
-  --outline-variant: #45484f;
+  --bg: #0E0C0A;
+  --bg-rgb: 14, 12, 10;
+  --bg-2: #15110D;
+  --bg-3: #1C1712;
+  --fg: #EFE6D8;
+  --fg-dim: #A89C8A;
+  --fg-faint: #6B6253;
+  --line: rgba(239, 230, 216, 0.08);
+  --line-strong: rgba(239, 230, 216, 0.18);
+  --accent: #E8A253;
+  --accent-dim: #B67B3A;
+  --green: #8FB67B;
+  --blue: #7BA3B6;
+  --red: #C9685C;
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --serif: 'Instrument Serif', 'Times New Roman', serif;
+  --sans: 'Inter', -apple-system, system-ui, sans-serif;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-surface: var(--surface);
-  --color-surface-low: var(--surface-container-low);
-  --color-surface-mid: var(--surface-container);
-  --color-surface-high: var(--surface-container-high);
-  --color-surface-highest: var(--surface-container-highest);
-  --color-surface-bright: var(--surface-bright);
-  --color-surface-variant: var(--surface-variant);
-  --color-primary: var(--primary);
-  --color-primary-dim: var(--primary-dim);
-  --color-secondary: var(--secondary);
-  --color-secondary-dim: var(--secondary-dim);
-  --color-tertiary: var(--tertiary);
-  --color-on-surface: var(--on-surface);
-  --color-on-surface-variant: var(--on-surface-variant);
-  --color-outline: var(--outline);
-  --color-outline-variant: var(--outline-variant);
-  --font-sans: var(--font-manrope);
-  --font-body: var(--font-inter);
+  --color-bg: var(--bg);
+  --color-bg-2: var(--bg-2);
+  --color-bg-3: var(--bg-3);
+  --color-fg: var(--fg);
+  --color-fg-dim: var(--fg-dim);
+  --color-fg-faint: var(--fg-faint);
+  --color-line: var(--line);
+  --color-line-strong: var(--line-strong);
+  --color-accent: var(--accent);
+  --color-accent-dim: var(--accent-dim);
+  --color-green: var(--green);
+  --color-blue: var(--blue);
+  --color-red: var(--red);
+  --font-mono: var(--mono);
+  --font-serif: var(--serif);
+  --font-sans: var(--sans);
 }
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-}
+* { box-sizing: border-box; margin: 0; padding: 0; }
 
-/* Gradient text utility */
-.gradient-text {
-  background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Gradient button */
-.gradient-btn {
-  background: linear-gradient(135deg, var(--primary-dim) 0%, var(--secondary) 100%);
-}
-
-/* Ghost border */
-.ghost-border {
-  border: 1px solid rgba(69, 72, 79, 0.2);
-}
-
-/* Glass effect */
-.glass {
-  background: rgba(34, 38, 47, 0.4);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-}
-
-/* Ambient glow */
-.glow-primary {
-  box-shadow: 0 0 48px -12px rgba(108, 92, 231, 0.15);
-}
-
-.glow-secondary {
-  box-shadow: 0 0 48px -12px rgba(0, 210, 255, 0.15);
-}
-
-/* Hero aurora effect */
-@keyframes aurora {
-  0%, 100% {
-    transform: translate(0, 0) rotate(0deg) scale(1);
-  }
-  25% {
-    transform: translate(60px, -40px) rotate(45deg) scale(1.1);
-  }
-  50% {
-    transform: translate(-30px, 30px) rotate(90deg) scale(0.95);
-  }
-  75% {
-    transform: translate(40px, 20px) rotate(135deg) scale(1.05);
-  }
-}
-
-.aurora-blob {
-  animation: aurora 20s ease-in-out infinite;
-  will-change: transform;
-}
-
-.aurora-blob-2 {
-  animation: aurora 25s ease-in-out infinite reverse;
-  will-change: transform;
-}
-
-.aurora-blob-3 {
-  animation: aurora 18s ease-in-out infinite;
-  animation-delay: -7s;
-  will-change: transform;
-}
-
-/* Animated gradient border on hero photo */
-@keyframes border-rotate {
-  0% { --border-angle: 0deg; }
-  100% { --border-angle: 360deg; }
-}
-
-@property --border-angle {
-  syntax: "<angle>";
-  initial-value: 0deg;
-  inherits: false;
-}
-
-.rotating-border {
-  position: relative;
-}
-
-.rotating-border::before {
-  content: "";
-  position: absolute;
-  inset: -2px;
-  border-radius: 1rem;
-  padding: 2px;
-  background: conic-gradient(
-    from var(--border-angle),
-    transparent 40%,
-    var(--primary-dim) 50%,
-    var(--secondary) 60%,
-    transparent 70%
-  );
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  -webkit-mask-composite: xor;
-  animation: border-rotate 4s linear infinite;
-}
-
-/* Smooth scrolling */
 html {
   scroll-behavior: smooth;
 }
 
-/* Selection color */
-::selection {
-  background: rgba(108, 92, 231, 0.3);
-  color: #ecedf6;
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+  position: relative;
 }
+
+/* Grain overlay */
+body.grain::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 100;
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/></filter><rect width='100%25' height='100%25' filter='url(%23n)' opacity='0.8'/></svg>");
+}
+
+::selection { background: var(--accent); color: var(--bg); }
+
+/* Blink animation */
+@keyframes blink { 50% { opacity: 0; } }
+.blink { animation: blink 1.05s steps(1) infinite; }
+
+/* Pulse animation */
+@keyframes pulse { 50% { opacity: 0.4; } }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -43,11 +43,13 @@
 
 html {
   scroll-behavior: smooth;
+  background: var(--bg) !important;
+  color: var(--fg) !important;
 }
 
 body {
-  background: var(--bg);
-  color: var(--fg);
+  background: var(--bg) !important;
+  color: var(--fg) !important;
   font-family: var(--sans);
   font-size: 16px;
   line-height: 1.55;
@@ -71,9 +73,127 @@ body.grain::before {
 
 ::selection { background: var(--accent); color: var(--bg); }
 
+/* Italic accent emphasis (used in headings via dangerouslySetInnerHTML) */
+em {
+  font-style: italic;
+  color: var(--accent);
+}
+
 /* Blink animation */
 @keyframes blink { 50% { opacity: 0; } }
 .blink { animation: blink 1.05s steps(1) infinite; }
 
 /* Pulse animation */
 @keyframes pulse { 50% { opacity: 0.4; } }
+
+/* ============ Hero responsive ============ */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 420px;
+  gap: 48px;
+  align-items: end;
+}
+@media (max-width: 1080px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+}
+@media (max-width: 640px) {
+  .hero-grid h1 {
+    font-size: 42px !important;
+  }
+}
+
+/* ============ Project body responsive ============ */
+.project-body {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 48px;
+  padding: 36px 28px 40px;
+}
+@media (max-width: 1080px) {
+  .project-body {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 28px 20px 32px;
+  }
+}
+
+/* ============ Project grid responsive ============ */
+.project-grid {
+  display: grid;
+  grid-template-columns: 56px 1fr;
+}
+@media (max-width: 640px) {
+  .project-grid {
+    grid-template-columns: 36px 1fr;
+  }
+}
+
+/* ============ Experience row responsive ============ */
+.exp-row {
+  display: grid;
+  grid-template-columns: 56px 160px 1fr 1fr;
+  gap: 32px;
+  padding: 28px;
+  align-items: start;
+}
+@media (max-width: 1080px) {
+  .exp-row {
+    grid-template-columns: 40px 110px 1fr;
+  }
+  .exp-row .exp-desc {
+    grid-column: 3 / 4;
+    grid-row: 2;
+    margin-top: 8px;
+  }
+}
+@media (max-width: 640px) {
+  .exp-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 20px 18px;
+  }
+}
+
+/* ============ About grid responsive ============ */
+.about-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 64px;
+  align-items: start;
+}
+@media (max-width: 1080px) {
+  .about-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============ Contact grid responsive ============ */
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 48px;
+  align-items: end;
+}
+@media (max-width: 1080px) {
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============ Outcome grid ============ */
+.outcome-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 22px;
+  align-items: center;
+}
+
+/* ============ Project meta kv grid ============ */
+.meta-kv {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  row-gap: 6px;
+  column-gap: 14px;
+}

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -3,82 +3,161 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import FadeIn from "./FadeIn";
+import SectionHeader from "./SectionHeader";
 
 const techStack = [
-  "TypeScript",
-  "React",
-  "Node.js",
-  "Python",
-  "Go",
-  "GraphQL",
-  "PostgreSQL",
-  "AWS",
-  "GCP",
-  "Docker",
-  "Temporal",
-  "PyTorch",
+  { label: "TypeScript", accent: true },
+  { label: "React", accent: true },
+  { label: "Node.js", accent: false },
+  { label: "Python", accent: false },
+  { label: "Go", accent: false },
+  { label: "GraphQL", accent: false },
+  { label: "PostgreSQL", accent: false },
+  { label: "AWS", accent: false },
+  { label: "GCP", accent: false },
+  { label: "Docker", accent: false },
+  { label: "Temporal", accent: false },
+  { label: "PyTorch", accent: false },
 ];
 
 export default function About() {
   const t = useTranslations("About");
 
   return (
-    <section id="about" className="relative py-32">
-      <div className="max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-16">
-            {t("heading")}
-          </h2>
-        </FadeIn>
+    <section id="about">
+      <SectionHeader
+        idx="05"
+        file="about.md"
+        title={t("heading")}
+      />
 
-        <div className="grid md:grid-cols-[280px_1fr] gap-12 items-start">
-          <FadeIn>
-            <div className="aspect-[3/4] rounded-2xl bg-surface-low ghost-border overflow-hidden">
+      <FadeIn>
+        <div
+          className="grid gap-[64px] px-[28px] pb-[56px] items-start"
+          style={{ gridTemplateColumns: "1fr 1.4fr" }}
+        >
+          {/* Portrait */}
+          <aside className="sticky top-[120px]">
+            <div
+              className="w-full aspect-[3/4] rounded-[4px] border relative overflow-hidden flex items-end justify-start p-[18px]"
+              style={{
+                borderColor: "var(--line-strong)",
+                background: `repeating-linear-gradient(45deg, rgba(232,162,83,0.08) 0, rgba(232,162,83,0.08) 1px, transparent 1px, transparent 12px), linear-gradient(180deg, var(--bg-3), var(--bg-2))`,
+              }}
+            >
               <Image
                 src="/juan-murillo.jpg"
                 alt="Juan Murillo"
-                width={280}
-                height={373}
-                className="object-cover w-full h-full"
+                fill
+                className="object-cover"
+              />
+              <div className="relative z-10">
+                <div
+                  style={{
+                    fontFamily: "var(--serif)",
+                    fontSize: "48px",
+                    lineHeight: 0.95,
+                    letterSpacing: "-0.02em",
+                    color: "var(--fg)",
+                    textShadow: "0 2px 12px rgba(0,0,0,0.7)",
+                  }}
+                >
+                  Juan
+                  <br />
+                  Murillo
+                  <span
+                    className="block mt-[8px]"
+                    style={{
+                      fontFamily: "var(--mono)",
+                      fontSize: "11px",
+                      color: "var(--fg-faint)",
+                      letterSpacing: "0.05em",
+                      textTransform: "uppercase",
+                      textShadow: "0 1px 8px rgba(0,0,0,0.9)",
+                    }}
+                  >
+                    {t("location")}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          {/* Body */}
+          <div>
+            <div className="space-y-[24px]">
+              <p
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: "22px",
+                  lineHeight: 1.45,
+                  color: "var(--fg)",
+                  textWrap: "pretty",
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: t.raw("paragraph1"),
+                }}
+              />
+              <p
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: "22px",
+                  lineHeight: 1.45,
+                  color: "var(--fg-dim)",
+                  textWrap: "pretty",
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: t.raw("paragraph2"),
+                }}
+              />
+              <p
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: "22px",
+                  lineHeight: 1.45,
+                  color: "var(--fg-dim)",
+                  textWrap: "pretty",
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: t.raw("paragraph3"),
+                }}
               />
             </div>
-          </FadeIn>
 
-          <FadeIn delay={150}>
-            <div className="font-[family-name:var(--font-inter)] text-on-surface-variant leading-relaxed space-y-4">
-              <p>
-                {t.rich("paragraph1", {
-                  strong: (chunks) => (
-                    <strong className="text-on-surface">{chunks}</strong>
-                  ),
-                })}
-              </p>
-              <p>{t("paragraph2")}</p>
-              <p>
-                {t.rich("paragraph3", {
-                  strong: (chunks) => (
-                    <strong className="text-on-surface">{chunks}</strong>
-                  ),
-                })}
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-2 mt-8">
+            <div className="flex flex-wrap gap-[6px] mt-[40px]">
               {techStack.map((tech) => (
                 <span
-                  key={tech}
-                  className="text-xs font-[family-name:var(--font-inter)] px-3 py-1.5 rounded-md bg-surface-low ghost-border text-on-surface-variant/70"
+                  key={tech.label}
+                  className="rounded-[2px] px-[10px] py-[5px]"
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: "11px",
+                    color: tech.accent
+                      ? "var(--accent)"
+                      : "var(--fg)",
+                    border: `1px solid ${
+                      tech.accent
+                        ? "rgba(232,162,83,0.35)"
+                        : "var(--line-strong)"
+                    }`,
+                    background: "var(--bg-2)",
+                  }}
                 >
-                  {tech}
+                  {tech.label}
                 </span>
               ))}
             </div>
-          </FadeIn>
+          </div>
         </div>
-      </div>
+      </FadeIn>
+
+      <style jsx>{`
+        @media (max-width: 1080px) {
+          div[style*="grid-template-columns: 1fr 1.4fr"] {
+            grid-template-columns: 1fr !important;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -25,21 +25,14 @@ export default function About() {
 
   return (
     <section id="about">
-      <SectionHeader
-        idx="05"
-        file="about.md"
-        title={t("heading")}
-      />
+      <SectionHeader idx="05" file="about.md" title={t.raw("heading")} />
 
       <FadeIn>
-        <div
-          className="grid gap-[64px] px-[28px] pb-[56px] items-start"
-          style={{ gridTemplateColumns: "1fr 1.4fr" }}
-        >
+        <div className="about-grid px-7 pb-14">
           {/* Portrait */}
           <aside className="sticky top-[120px]">
             <div
-              className="w-full aspect-[3/4] rounded-[4px] border relative overflow-hidden flex items-end justify-start p-[18px]"
+              className="w-full aspect-[3/4] rounded border relative overflow-hidden flex items-end justify-start p-4"
               style={{
                 borderColor: "var(--line-strong)",
                 background: `repeating-linear-gradient(45deg, rgba(232,162,83,0.08) 0, rgba(232,162,83,0.08) 1px, transparent 1px, transparent 12px), linear-gradient(180deg, var(--bg-3), var(--bg-2))`,
@@ -55,7 +48,7 @@ export default function About() {
                 <div
                   style={{
                     fontFamily: "var(--serif)",
-                    fontSize: "48px",
+                    fontSize: "clamp(32px, 4vw, 48px)",
                     lineHeight: 0.95,
                     letterSpacing: "-0.02em",
                     color: "var(--fg)",
@@ -66,7 +59,7 @@ export default function About() {
                   <br />
                   Murillo
                   <span
-                    className="block mt-[8px]"
+                    className="block mt-2"
                     style={{
                       fontFamily: "var(--mono)",
                       fontSize: "11px",
@@ -85,56 +78,45 @@ export default function About() {
 
           {/* Body */}
           <div>
-            <div className="space-y-[24px]">
+            <div className="space-y-6">
               <p
                 style={{
                   fontFamily: "var(--serif)",
-                  fontSize: "22px",
+                  fontSize: "clamp(18px, 2vw, 22px)",
                   lineHeight: 1.45,
                   color: "var(--fg)",
-                  textWrap: "pretty",
                 }}
-                dangerouslySetInnerHTML={{
-                  __html: t.raw("paragraph1"),
-                }}
+                dangerouslySetInnerHTML={{ __html: t.raw("paragraph1") }}
               />
               <p
                 style={{
                   fontFamily: "var(--serif)",
-                  fontSize: "22px",
+                  fontSize: "clamp(18px, 2vw, 22px)",
                   lineHeight: 1.45,
                   color: "var(--fg-dim)",
-                  textWrap: "pretty",
                 }}
-                dangerouslySetInnerHTML={{
-                  __html: t.raw("paragraph2"),
-                }}
+                dangerouslySetInnerHTML={{ __html: t.raw("paragraph2") }}
               />
               <p
                 style={{
                   fontFamily: "var(--serif)",
-                  fontSize: "22px",
+                  fontSize: "clamp(18px, 2vw, 22px)",
                   lineHeight: 1.45,
                   color: "var(--fg-dim)",
-                  textWrap: "pretty",
                 }}
-                dangerouslySetInnerHTML={{
-                  __html: t.raw("paragraph3"),
-                }}
+                dangerouslySetInnerHTML={{ __html: t.raw("paragraph3") }}
               />
             </div>
 
-            <div className="flex flex-wrap gap-[6px] mt-[40px]">
+            <div className="flex flex-wrap gap-1.5 mt-10">
               {techStack.map((tech) => (
                 <span
                   key={tech.label}
-                  className="rounded-[2px] px-[10px] py-[5px]"
+                  className="rounded-sm px-2.5 py-1"
                   style={{
                     fontFamily: "var(--mono)",
                     fontSize: "11px",
-                    color: tech.accent
-                      ? "var(--accent)"
-                      : "var(--fg)",
+                    color: tech.accent ? "var(--accent)" : "var(--fg)",
                     border: `1px solid ${
                       tech.accent
                         ? "rgba(232,162,83,0.35)"
@@ -150,14 +132,6 @@ export default function About() {
           </div>
         </div>
       </FadeIn>
-
-      <style jsx>{`
-        @media (max-width: 1080px) {
-          div[style*="grid-template-columns: 1fr 1.4fr"] {
-            grid-template-columns: 1fr !important;
-          }
-        }
-      `}</style>
     </section>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -28,7 +28,7 @@ export default function About() {
       <SectionHeader idx="05" file="about.md" title={t.raw("heading")} />
 
       <FadeIn>
-        <div className="about-grid px-7 pb-14">
+        <div className="wrap about-grid pb-14">
           {/* Portrait */}
           <aside className="sticky top-[120px]">
             <div

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -79,6 +79,18 @@ export default function CommandPalette() {
     },
     {
       group: t("actions"),
+      label: t("copyMarkdown"),
+      hint: "⌘⇧C",
+      icon: "MD",
+      action: () => {
+        const btn = document.querySelector(
+          "button[title*='Markdown']"
+        ) as HTMLButtonElement;
+        btn?.click();
+      },
+    },
+    {
+      group: t("actions"),
       label: t("copyEmail"),
       hint: "copy",
       icon: "@",

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface Command {
+  group: string;
+  label: string;
+  hint: string;
+  icon: string;
+  accent?: string;
+  action: () => void;
+}
+
+export default function CommandPalette() {
+  const t = useTranslations("CommandPalette");
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [sel, setSel] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const keyboardLockRef = useRef(false);
+  const keyboardLockTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const jump = useCallback((id: string) => {
+    const el = document.querySelector(id);
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  const commands: Command[] = [
+    {
+      group: t("navigate"),
+      label: t("goToTop"),
+      hint: "home",
+      icon: "↑",
+      action: () => window.scrollTo({ top: 0, behavior: "smooth" }),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToWork"),
+      hint: "01",
+      icon: "01",
+      action: () => jump("#work"),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToServices"),
+      hint: "02",
+      icon: "02",
+      action: () => jump("#services"),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToExperience"),
+      hint: "03",
+      icon: "03",
+      action: () => jump("#experience"),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToNow"),
+      hint: "04",
+      icon: "04",
+      action: () => jump("#now"),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToAbout"),
+      hint: "05",
+      icon: "05",
+      action: () => jump("#about"),
+    },
+    {
+      group: t("navigate"),
+      label: t("goToContact"),
+      hint: "06",
+      icon: "06",
+      action: () => jump("#contact"),
+    },
+    {
+      group: t("actions"),
+      label: t("copyEmail"),
+      hint: "copy",
+      icon: "@",
+      action: () => {
+        navigator.clipboard?.writeText("juanchomurcas@gmail.com");
+      },
+    },
+    {
+      group: t("actions"),
+      label: t("openLinkedIn"),
+      hint: "external",
+      icon: "in",
+      action: () => window.open("https://linkedin.com/in/juan-murillo", "_blank"),
+    },
+    {
+      group: t("actions"),
+      label: t("openGitHub"),
+      hint: "external",
+      icon: "{ }",
+      action: () => window.open("https://github.com/jgmurillo10", "_blank"),
+    },
+    {
+      group: t("actions"),
+      label: t("sendEmail"),
+      hint: "mailto",
+      icon: "✉",
+      action: () => {
+        window.location.href = "mailto:juanchomurcas@gmail.com";
+      },
+    },
+  ];
+
+  const filtered = query
+    ? commands.filter(
+        (c) =>
+          c.label.toLowerCase().includes(query.toLowerCase()) ||
+          c.group.toLowerCase().includes(query.toLowerCase()) ||
+          c.hint.toLowerCase().includes(query.toLowerCase())
+      )
+    : commands;
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+    setQuery("");
+    setSel(0);
+    setTimeout(() => inputRef.current?.focus(), 20);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const execute = useCallback(
+    (i: number) => {
+      const c = filtered[i];
+      if (!c) return;
+      c.action();
+      handleClose();
+    },
+    [filtered, handleClose]
+  );
+
+  const lockKeyboard = useCallback(() => {
+    keyboardLockRef.current = true;
+    clearTimeout(keyboardLockTimeoutRef.current);
+    keyboardLockTimeoutRef.current = setTimeout(() => {
+      keyboardLockRef.current = false;
+    }, 400);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        open ? handleClose() : handleOpen();
+      } else if (
+        e.key === "/" &&
+        !open &&
+        !/input|textarea/i.test(
+          (document.activeElement as HTMLElement)?.tagName || ""
+        )
+      ) {
+        e.preventDefault();
+        handleOpen();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, handleOpen, handleClose]);
+
+  useEffect(() => {
+    setSel(0);
+  }, [query]);
+
+  useEffect(() => {
+    const active = listRef.current?.querySelector(".cmdk-sel");
+    if (active) active.scrollIntoView({ block: "nearest" });
+  }, [sel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[2000] flex items-start justify-center pt-[14vh]"
+      style={{
+        background: "rgba(8, 6, 4, 0.6)",
+        backdropFilter: "blur(6px)",
+        WebkitBackdropFilter: "blur(6px)",
+        animation: "cmdkFade 0.15s ease",
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) handleClose();
+      }}
+    >
+      <div
+        className="overflow-hidden rounded-[8px]"
+        style={{
+          width: "min(560px, calc(100vw - 40px))",
+          background: "var(--bg-2)",
+          border: "1px solid var(--line-strong)",
+          boxShadow:
+            "0 40px 100px rgba(0,0,0,0.7), 0 0 0 1px rgba(232,162,83,0.05)",
+          fontFamily: "var(--mono)",
+          animation: "cmdkPop 0.18s cubic-bezier(0.2,0.8,0.2,1)",
+        }}
+        role="dialog"
+        aria-label="Command palette"
+      >
+        {/* Input */}
+        <div
+          className="flex items-center gap-[10px] px-[16px] py-[14px] border-b"
+          style={{ borderColor: "var(--line)" }}
+        >
+          <span style={{ color: "var(--accent)", fontSize: "14px" }}>❯</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setSel((s) => (s + 1) % filtered.length);
+                lockKeyboard();
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setSel((s) => (s - 1 + filtered.length) % filtered.length);
+                lockKeyboard();
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                execute(sel);
+              } else if (e.key === "Escape") {
+                e.preventDefault();
+                handleClose();
+              }
+            }}
+            placeholder={t("placeholder")}
+            autoComplete="off"
+            spellCheck={false}
+            className="flex-1 border-0 outline-0"
+            style={{
+              background: "transparent",
+              color: "var(--fg)",
+              fontFamily: "var(--mono)",
+              fontSize: "14px",
+              caretColor: "var(--accent)",
+            }}
+          />
+          <span
+            className="rounded-[3px] border px-[7px] py-[2px]"
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: "10.5px",
+              color: "var(--fg-faint)",
+              borderColor: "var(--line-strong)",
+            }}
+          >
+            esc
+          </span>
+        </div>
+
+        {/* List */}
+        <div
+          ref={listRef}
+          className="max-h-[50vh] overflow-y-auto py-[6px]"
+        >
+          {filtered.length === 0 ? (
+            <div
+              className="py-[22px] px-[16px] text-center"
+              style={{ fontSize: "13px", color: "var(--fg-faint)" }}
+            >
+              {t("noResults")}
+            </div>
+          ) : (
+            (() => {
+              let lastGroup = "";
+              return filtered.map((c, i) => {
+                const showGroup = c.group !== lastGroup;
+                lastGroup = c.group;
+                return (
+                  <div key={`${c.group}-${c.label}`}>
+                    {showGroup && (
+                      <div
+                        className="px-[16px] pt-[10px] pb-[6px]"
+                        style={{
+                          fontSize: "10px",
+                          color: "var(--fg-faint)",
+                          letterSpacing: "0.1em",
+                          textTransform: "uppercase",
+                        }}
+                      >
+                        {c.group}
+                      </div>
+                    )}
+                    <div
+                      className={`flex items-center gap-[12px] px-[16px] py-[10px] cursor-pointer border-l-2 ${i === sel ? "cmdk-sel" : ""}`}
+                      style={{
+                        borderLeftColor:
+                          i === sel ? "var(--accent)" : "transparent",
+                        background:
+                          i === sel
+                            ? "rgba(232,162,83,0.08)"
+                            : "transparent",
+                        color: i === sel ? "var(--fg)" : "var(--fg-dim)",
+                        fontSize: "13px",
+                      }}
+                      onMouseMove={() => {
+                        if (keyboardLockRef.current) return;
+                        if (i !== sel) setSel(i);
+                      }}
+                      onClick={() => execute(i)}
+                    >
+                      <span
+                        className="w-[22px] h-[22px] rounded-[3px] inline-flex items-center justify-center shrink-0"
+                        style={{
+                          background:
+                            c.accent
+                              ? c.accent
+                              : i === sel
+                                ? "var(--accent)"
+                                : "var(--bg-3)",
+                          color:
+                            c.accent || i === sel
+                              ? "var(--bg)"
+                              : "var(--accent)",
+                          fontSize: "11px",
+                        }}
+                      >
+                        {c.icon}
+                      </span>
+                      <span style={{ color: "var(--fg)" }}>{c.label}</span>
+                      <span
+                        className="ml-auto"
+                        style={{
+                          color: "var(--fg-faint)",
+                          fontSize: "11px",
+                        }}
+                      >
+                        {c.hint}
+                      </span>
+                    </div>
+                  </div>
+                );
+              });
+            })()
+          )}
+        </div>
+
+        {/* Footer */}
+        <div
+          className="flex items-center gap-[14px] px-[16px] py-[10px] border-t"
+          style={{
+            borderColor: "var(--line)",
+            fontSize: "10.5px",
+            color: "var(--fg-faint)",
+          }}
+        >
+          <span>
+            <span
+              className="border rounded-[2px] px-[6px] py-[1px] mr-[5px]"
+              style={{
+                borderColor: "var(--line-strong)",
+                color: "var(--fg-dim)",
+              }}
+            >
+              ↑↓
+            </span>
+            {t("navLabel")}
+          </span>
+          <span>
+            <span
+              className="border rounded-[2px] px-[6px] py-[1px] mr-[5px]"
+              style={{
+                borderColor: "var(--line-strong)",
+                color: "var(--fg-dim)",
+              }}
+            >
+              ↵
+            </span>
+            {t("selectLabel")}
+          </span>
+          <span>
+            <span
+              className="border rounded-[2px] px-[6px] py-[1px] mr-[5px]"
+              style={{
+                borderColor: "var(--line-strong)",
+                color: "var(--fg-dim)",
+              }}
+            >
+              esc
+            </span>
+            {t("closeLabel")}
+          </span>
+          <span className="ml-auto" style={{ color: "var(--accent)" }}>
+            juan murillo · ⌘K
+          </span>
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes cmdkFade {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+        @keyframes cmdkPop {
+          from {
+            transform: translateY(8px) scale(0.98);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0) scale(1);
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -32,8 +32,9 @@ export default function Contact() {
   return (
     <section
       id="contact"
-      className="relative border-t border-line px-7 py-[70px] pb-20"
+      className="relative border-t border-line"
     >
+      <div className="wrap" style={{ paddingTop: "70px", paddingBottom: "80px" }}>
       <div
         className="flex items-baseline gap-4 mb-3 flex-wrap"
         style={{
@@ -135,6 +136,7 @@ export default function Contact() {
           </div>
         </div>
       </FadeIn>
+      </div>
     </section>
   );
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -32,11 +32,10 @@ export default function Contact() {
   return (
     <section
       id="contact"
-      className="relative border-t border-line"
-      style={{ padding: "70px 28px 80px" }}
+      className="relative border-t border-line px-7 py-[70px] pb-20"
     >
       <div
-        className="flex items-baseline gap-[18px] mb-[12px]"
+        className="flex items-baseline gap-4 mb-3 flex-wrap"
         style={{
           fontFamily: "var(--mono)",
           fontSize: "11px",
@@ -52,21 +51,20 @@ export default function Contact() {
 
       <FadeIn>
         <h2
-          className="mb-[32px]"
+          className="mb-8"
           style={{
             fontFamily: "var(--serif)",
             fontWeight: 400,
-            fontSize: "clamp(48px, 7vw, 96px)",
+            fontSize: "clamp(36px, 7vw, 96px)",
             letterSpacing: "-0.025em",
             lineHeight: 1,
             maxWidth: "16ch",
-            textWrap: "balance",
           }}
           dangerouslySetInnerHTML={{ __html: t.raw("heading") }}
         />
 
         <p
-          className="max-w-[56ch] mb-[36px]"
+          className="max-w-[56ch] mb-9"
           style={{
             color: "var(--fg-dim)",
             fontSize: "17px",
@@ -76,26 +74,31 @@ export default function Contact() {
           {t("subheading")}
         </p>
 
-        <div
-          className="grid gap-[48px] items-end"
-          style={{ gridTemplateColumns: "1.3fr 1fr" }}
-        >
+        <div className="contact-grid">
           <a
             href="mailto:juanchomurcas@gmail.com"
-            className="inline-block no-underline border-b pb-[10px] transition-colors duration-200 hover:text-accent hover:border-accent"
+            className="inline-block no-underline border-b pb-2.5 transition-colors duration-200"
             style={{
               fontFamily: "var(--serif)",
-              fontSize: "clamp(26px, 3.2vw, 42px)",
+              fontSize: "clamp(20px, 3.2vw, 42px)",
               letterSpacing: "-0.01em",
               color: "var(--fg)",
               borderColor: "var(--line-strong)",
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.color = "var(--accent)";
+              e.currentTarget.style.borderColor = "var(--accent)";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.color = "var(--fg)";
+              e.currentTarget.style.borderColor = "var(--line-strong)";
             }}
           >
             juanchomurcas@gmail.com →
           </a>
 
           <div
-            className="flex flex-col gap-[12px]"
+            className="flex flex-col gap-3"
             style={{
               fontFamily: "var(--mono)",
               fontSize: "13px",
@@ -111,10 +114,16 @@ export default function Contact() {
                     ? "noopener noreferrer"
                     : undefined
                 }
-                className="flex justify-between items-center py-[12px] border-b no-underline transition-all duration-200 hover:text-accent hover:pl-[8px]"
+                className="flex justify-between items-center py-3 border-b no-underline transition-all duration-200 hover:pl-2"
                 style={{
                   color: "var(--fg)",
                   borderColor: "var(--line)",
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.color = "var(--accent)";
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.color = "var(--fg)";
                 }}
               >
                 <span>{link.label}</span>
@@ -126,14 +135,6 @@ export default function Contact() {
           </div>
         </div>
       </FadeIn>
-
-      <style jsx>{`
-        @media (max-width: 1080px) {
-          div[style*="grid-template-columns: 1.3fr 1fr"] {
-            grid-template-columns: 1fr !important;
-          }
-        }
-      `}</style>
     </section>
   );
 }

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -6,58 +6,134 @@ import FadeIn from "./FadeIn";
 export default function Contact() {
   const t = useTranslations("Contact");
 
+  const links = [
+    {
+      label: "LinkedIn",
+      href: "https://linkedin.com/in/juan-murillo",
+      arrow: "↗",
+    },
+    {
+      label: "GitHub",
+      href: "https://github.com/jgmurillo10",
+      arrow: "↗",
+    },
+    {
+      label: t("talkLink"),
+      href: "#",
+      arrow: "↗",
+    },
+    {
+      label: t("cvLink"),
+      href: "#",
+      arrow: "↓",
+    },
+  ];
+
   return (
-    <section id="contact" className="relative py-32 bg-surface-low">
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[500px] h-[300px] bg-primary-dim/5 rounded-full blur-[100px]" />
+    <section
+      id="contact"
+      className="relative border-t border-line"
+      style={{ padding: "70px 28px 80px" }}
+    >
+      <div
+        className="flex items-baseline gap-[18px] mb-[12px]"
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: "11px",
+          color: "var(--fg-faint)",
+          letterSpacing: "0.08em",
+          textTransform: "uppercase",
+        }}
+      >
+        <span>// 06</span>
+        <span>─────────</span>
+        <span>contact.md</span>
       </div>
 
-      <div className="relative max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-4">
-            {t("heading")}
-          </h2>
-          <p className="font-[family-name:var(--font-inter)] text-on-surface-variant max-w-lg leading-relaxed mb-12">
-            {t("subheading")}
-          </p>
-        </FadeIn>
+      <FadeIn>
+        <h2
+          className="mb-[32px]"
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: "clamp(48px, 7vw, 96px)",
+            letterSpacing: "-0.025em",
+            lineHeight: 1,
+            maxWidth: "16ch",
+            textWrap: "balance",
+          }}
+          dangerouslySetInnerHTML={{ __html: t.raw("heading") }}
+        />
 
-        <FadeIn delay={150}>
-          <div className="flex flex-col sm:flex-row gap-4 mb-12">
-            <a
-              href="mailto:juanchomurcas@gmail.com"
-              className="gradient-btn text-black font-medium font-[family-name:var(--font-inter)] px-6 py-3 rounded-lg hover:opacity-90 transition-opacity text-sm text-center"
-            >
-              juanchomurcas@gmail.com
-            </a>
-            <a
-              href="https://linkedin.com/in/juan-murillo"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ghost-border text-on-surface-variant font-medium font-[family-name:var(--font-inter)] px-6 py-3 rounded-lg hover:text-on-surface hover:bg-surface-highest/40 transition-colors text-sm text-center"
-            >
-              LinkedIn
-            </a>
-            <a
-              href="https://github.com/jgmurillo10"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ghost-border text-on-surface-variant font-medium font-[family-name:var(--font-inter)] px-6 py-3 rounded-lg hover:text-on-surface hover:bg-surface-highest/40 transition-colors text-sm text-center"
-            >
-              GitHub
-            </a>
+        <p
+          className="max-w-[56ch] mb-[36px]"
+          style={{
+            color: "var(--fg-dim)",
+            fontSize: "17px",
+            lineHeight: 1.6,
+          }}
+        >
+          {t("subheading")}
+        </p>
+
+        <div
+          className="grid gap-[48px] items-end"
+          style={{ gridTemplateColumns: "1.3fr 1fr" }}
+        >
+          <a
+            href="mailto:juanchomurcas@gmail.com"
+            className="inline-block no-underline border-b pb-[10px] transition-colors duration-200 hover:text-accent hover:border-accent"
+            style={{
+              fontFamily: "var(--serif)",
+              fontSize: "clamp(26px, 3.2vw, 42px)",
+              letterSpacing: "-0.01em",
+              color: "var(--fg)",
+              borderColor: "var(--line-strong)",
+            }}
+          >
+            juanchomurcas@gmail.com →
+          </a>
+
+          <div
+            className="flex flex-col gap-[12px]"
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: "13px",
+            }}
+          >
+            {links.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target={link.href.startsWith("http") ? "_blank" : undefined}
+                rel={
+                  link.href.startsWith("http")
+                    ? "noopener noreferrer"
+                    : undefined
+                }
+                className="flex justify-between items-center py-[12px] border-b no-underline transition-all duration-200 hover:text-accent hover:pl-[8px]"
+                style={{
+                  color: "var(--fg)",
+                  borderColor: "var(--line)",
+                }}
+              >
+                <span>{link.label}</span>
+                <span style={{ color: "var(--fg-faint)" }}>
+                  {link.arrow}
+                </span>
+              </a>
+            ))}
           </div>
-        </FadeIn>
+        </div>
+      </FadeIn>
 
-        <FadeIn delay={250}>
-          <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant/40">
-            {t("basedIn")}
-          </p>
-        </FadeIn>
-      </div>
+      <style jsx>{`
+        @media (max-width: 1080px) {
+          div[style*="grid-template-columns: 1.3fr 1fr"] {
+            grid-template-columns: 1fr !important;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/src/components/CopyMarkdown.tsx
+++ b/src/components/CopyMarkdown.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+function buildMarkdown(): string {
+  const out: string[] = [];
+  const nl = () => out.push("");
+  const text = (el: Element | null) =>
+    el ? (el.textContent || "").replace(/\s+/g, " ").trim() : "";
+
+  // Title
+  const h1 = document.querySelector(".hero-grid h1, #top h1");
+  if (h1) out.push("# " + text(h1));
+
+  const crumb = document.querySelector("[class*='hero'] [class*='crumb'], #top > div > div:first-child");
+  if (crumb) out.push("> " + text(crumb));
+  nl();
+
+  // Terminal whoami
+  const termLines = document.querySelectorAll("[aria-hidden] .p-4 div, .term-body .ln");
+  if (termLines.length) {
+    out.push("## whoami");
+    termLines.forEach((ln) => {
+      const t = text(ln);
+      if (/stack|infra|ai|teams/i.test(t.split(":")[0] || "")) {
+        const [k, ...rest] = t.split(":");
+        if (rest.length) out.push(`- **${k.trim()}:** ${rest.join(":").trim()}`);
+      } else if (/^✓/.test(t)) {
+        out.push("- " + t);
+      }
+    });
+    nl();
+  }
+
+  // Sections
+  document.querySelectorAll("main > section[id]").forEach((section) => {
+    if (section.id === "top") return;
+    const head = section.querySelector("h2");
+    if (!head) return;
+    out.push("## " + text(head).replace(/[*]/g, ""));
+    nl();
+
+    // Projects
+    section.querySelectorAll("article").forEach((p) => {
+      const name = p.querySelector("[style*='serif']");
+      const h3 = p.querySelector("h3");
+      if (name) out.push("### " + text(name));
+      if (h3) out.push("**" + text(h3) + "**");
+      nl();
+
+      p.querySelectorAll("p").forEach((para) => {
+        out.push(text(para));
+        nl();
+      });
+      out.push("---");
+      nl();
+    });
+
+    // Services
+    section.querySelectorAll("[class*='service'] > div, .lg\\:grid-cols-3 > div").forEach((s) => {
+      const h3 = s.querySelector("h3");
+      const p = s.querySelector("p");
+      if (h3) out.push("### " + text(h3));
+      if (p) out.push(text(p));
+      nl();
+    });
+
+    // Experience rows
+    section.querySelectorAll(".exp-row").forEach((r) => {
+      const who = r.querySelector("h4");
+      const role = r.querySelector("[style*='mono'][class*='mt']");
+      const desc = r.querySelector(".exp-desc");
+      if (who) {
+        out.push(`### ${text(who)}`);
+        if (role) out.push(`_${text(role)}_`);
+        if (desc) out.push(text(desc));
+        nl();
+      }
+    });
+
+    // Now cards
+    section.querySelectorAll("[style*='bg-2']").forEach((c) => {
+      const h = c.querySelector("h4");
+      const p = c.querySelector("p");
+      if (h) out.push("### " + text(h));
+      if (p) out.push(text(p));
+      nl();
+    });
+  });
+
+  // Footer
+  const footer = document.querySelector("footer");
+  if (footer) {
+    out.push("---");
+    out.push("_" + text(footer) + "_");
+  }
+
+  return out
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim() + "\n";
+}
+
+export default function CopyMarkdown() {
+  const [copied, setCopied] = useState(false);
+  const [charCount, setCharCount] = useState(0);
+
+  const handleCopy = useCallback(async () => {
+    const md = buildMarkdown();
+    try {
+      await navigator.clipboard.writeText(md);
+    } catch {
+      const ta = document.createElement("textarea");
+      ta.value = md;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      ta.remove();
+    }
+    setCharCount(md.length);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+
+  return (
+    <button
+      className="fixed left-5 bottom-5 z-[900] inline-flex items-center gap-2 rounded-full cursor-pointer transition-all duration-150 hover:-translate-y-0.5"
+      style={{
+        background: "var(--bg-2)",
+        border: `1px solid ${copied ? "var(--green)" : "var(--line-strong)"}`,
+        color: copied ? "var(--green)" : "var(--fg)",
+        fontFamily: "var(--mono)",
+        fontSize: "12px",
+        padding: "10px 16px",
+        boxShadow: "0 10px 30px rgba(0,0,0,0.4)",
+      }}
+      onClick={handleCopy}
+      title="Copy this page as Markdown (⌘⇧C)"
+    >
+      <span
+        className="w-[18px] h-[18px] rounded inline-flex items-center justify-center"
+        style={{
+          background: copied ? "var(--green)" : "var(--accent)",
+          color: "var(--bg)",
+          fontSize: "10px",
+          fontWeight: 700,
+        }}
+      >
+        {copied ? "✓" : "MD"}
+      </span>
+      <span>
+        {copied
+          ? `copied · ${charCount.toLocaleString()} chars`
+          : "copy as markdown"}
+      </span>
+    </button>
+  );
+}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -2,56 +2,105 @@
 
 import { useTranslations } from "next-intl";
 import FadeIn from "./FadeIn";
+import SectionHeader from "./SectionHeader";
 
 const timelineKeys = [0, 1, 2, 3];
-const currentIndex = 0;
+const lineNumbers = ["037", "038", "039", "040"];
 
 export default function Experience() {
   const t = useTranslations("Experience");
 
   return (
-    <section id="experience" className="relative py-32 bg-surface-low">
-      <div className="max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-16">
-            {t("heading")}
-          </h2>
-        </FadeIn>
+    <section id="experience">
+      <SectionHeader
+        idx="03"
+        file="experience.md"
+        title={t("heading")}
+        lede={t("subheading")}
+      />
 
-        <div className="relative">
-          <div className="absolute left-0 top-0 bottom-0 w-px bg-outline-variant/20" />
-
-          <div className="space-y-10">
-            {timelineKeys.map((i) => (
-              <FadeIn key={i} delay={i * 80}>
-                <div className="relative pl-8">
-                  <div
-                    className={`absolute left-0 top-2 w-2 h-2 rounded-full -translate-x-[3.5px] ${
-                      i === currentIndex
-                        ? "bg-secondary shadow-[0_0_8px_rgba(0,210,255,0.5)]"
-                        : "bg-outline-variant/50"
-                    }`}
-                  />
-                  <div className="flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-3 mb-2">
-                    <h3 className="font-[family-name:var(--font-manrope)] font-bold">
-                      {t(`timeline.${i}.company`)}
-                    </h3>
-                    <span className="font-[family-name:var(--font-inter)] text-xs text-on-surface-variant/50">
-                      {t(`timeline.${i}.role`)} · {t(`timeline.${i}.period`)}
-                    </span>
-                  </div>
-                  <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                    {t(`timeline.${i}.description`)}
-                  </p>
+      <FadeIn>
+        <div className="border-t border-line">
+          {timelineKeys.map((i) => (
+            <div
+              key={i}
+              className="grid gap-[32px] px-[28px] py-[28px] border-b border-line items-start transition-colors duration-200 hover:bg-accent/[0.02] cursor-default"
+              style={{
+                gridTemplateColumns: "56px 160px 1fr 1fr",
+              }}
+            >
+              <div
+                className="text-right"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  color: "var(--fg-faint)",
+                }}
+              >
+                {lineNumbers[i]}
+              </div>
+              <div
+                className="pt-[4px]"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "12px",
+                  color: "var(--accent)",
+                  letterSpacing: "0.02em",
+                }}
+              >
+                {t(`timeline.${i}.period`)}
+              </div>
+              <div>
+                <h4
+                  style={{
+                    fontFamily: "var(--serif)",
+                    fontSize: "26px",
+                    fontWeight: 400,
+                    letterSpacing: "-0.01em",
+                    lineHeight: 1.1,
+                  }}
+                >
+                  {t(`timeline.${i}.company`)}
+                </h4>
+                <div
+                  className="mt-[6px]"
+                  style={{
+                    fontFamily: "var(--mono)",
+                    fontSize: "12px",
+                    color: "var(--fg-dim)",
+                  }}
+                >
+                  {t(`timeline.${i}.role`)}
                 </div>
-              </FadeIn>
-            ))}
-          </div>
+              </div>
+              <div
+                style={{
+                  color: "var(--fg-dim)",
+                  fontSize: "14.5px",
+                  lineHeight: 1.6,
+                }}
+              >
+                {t(`timeline.${i}.description`)}
+              </div>
+            </div>
+          ))}
         </div>
-      </div>
+      </FadeIn>
+
+      <style jsx>{`
+        @media (max-width: 1080px) {
+          div[style*="grid-template-columns: 56px 160px"] {
+            grid-template-columns: 40px 110px 1fr !important;
+          }
+        }
+        @media (max-width: 640px) {
+          div[style*="grid-template-columns: 56px 160px"] {
+            grid-template-columns: 1fr !important;
+            gap: 8px !important;
+            padding: 20px 18px !important;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -20,7 +20,7 @@ export default function Experience() {
       />
 
       <FadeIn>
-        <div className="border-t border-line">
+        <div className="wrap border-t border-line" style={{ padding: 0 }}>
           {timelineKeys.map((i) => (
             <div
               key={i}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -15,7 +15,7 @@ export default function Experience() {
       <SectionHeader
         idx="03"
         file="experience.md"
-        title={t("heading")}
+        title={t.raw("heading")}
         lede={t("subheading")}
       />
 
@@ -24,10 +24,7 @@ export default function Experience() {
           {timelineKeys.map((i) => (
             <div
               key={i}
-              className="grid gap-[32px] px-[28px] py-[28px] border-b border-line items-start transition-colors duration-200 hover:bg-accent/[0.02] cursor-default"
-              style={{
-                gridTemplateColumns: "56px 160px 1fr 1fr",
-              }}
+              className="exp-row border-b border-line transition-colors duration-200 hover:bg-accent/[0.02] cursor-default"
             >
               <div
                 className="text-right"
@@ -40,7 +37,7 @@ export default function Experience() {
                 {lineNumbers[i]}
               </div>
               <div
-                className="pt-[4px]"
+                className="pt-1"
                 style={{
                   fontFamily: "var(--mono)",
                   fontSize: "12px",
@@ -63,7 +60,7 @@ export default function Experience() {
                   {t(`timeline.${i}.company`)}
                 </h4>
                 <div
-                  className="mt-[6px]"
+                  className="mt-1.5"
                   style={{
                     fontFamily: "var(--mono)",
                     fontSize: "12px",
@@ -74,6 +71,7 @@ export default function Experience() {
                 </div>
               </div>
               <div
+                className="exp-desc"
                 style={{
                   color: "var(--fg-dim)",
                   fontSize: "14.5px",
@@ -86,21 +84,6 @@ export default function Experience() {
           ))}
         </div>
       </FadeIn>
-
-      <style jsx>{`
-        @media (max-width: 1080px) {
-          div[style*="grid-template-columns: 56px 160px"] {
-            grid-template-columns: 40px 110px 1fr !important;
-          }
-        }
-        @media (max-width: 640px) {
-          div[style*="grid-template-columns: 56px 160px"] {
-            grid-template-columns: 1fr !important;
-            gap: 8px !important;
-            padding: 20px 18px !important;
-          }
-        }
-      `}</style>
     </section>
   );
 }

--- a/src/components/FeaturedWork.tsx
+++ b/src/components/FeaturedWork.tsx
@@ -40,26 +40,17 @@ export default function FeaturedWork() {
       <SectionHeader
         idx="01"
         file="selected_work.md"
-        title={t("heading")}
+        title={t.raw("heading")}
         lede={t("subheading")}
       />
 
       <div className="border-t border-line">
         {caseStudyData.map((study, i) => (
           <FadeIn key={study.index}>
-            <article
-              className="grid border-b border-line relative transition-colors duration-200 hover:bg-accent/[0.02] group"
-              style={{ gridTemplateColumns: "56px 1fr" }}
-            >
-              {/* Year tick */}
-              <div
-                className="absolute left-[-1px] top-[36px] w-[2px] bg-accent transition-all duration-300"
-                style={{ height: 0 }}
-              />
-
+            <article className="project-grid border-b border-line relative transition-colors duration-200 hover:bg-accent/[0.02]">
               {/* Line numbers */}
               <div
-                className="text-right py-[36px] px-[12px] select-none border-r border-line"
+                className="text-right py-9 px-3 select-none border-r border-line"
                 style={{
                   fontFamily: "var(--mono)",
                   fontSize: "11px",
@@ -70,16 +61,13 @@ export default function FeaturedWork() {
               </div>
 
               {/* Body */}
-              <div
-                className="p-[36px] pb-[40px] grid gap-[48px]"
-                style={{ gridTemplateColumns: "1fr 1.3fr" }}
-              >
+              <div className="project-body">
                 {/* Meta */}
-                <div className="flex flex-col gap-[16px]">
+                <div className="flex flex-col gap-4">
                   <div
                     style={{
                       fontFamily: "var(--serif)",
-                      fontSize: "48px",
+                      fontSize: "clamp(32px, 4vw, 48px)",
                       letterSpacing: "-0.02em",
                       lineHeight: 1,
                     }}
@@ -87,12 +75,11 @@ export default function FeaturedWork() {
                     {t(`studies.${i}.company`)}
                   </div>
                   <div
-                    className="grid gap-y-[6px] gap-x-[14px]"
+                    className="meta-kv"
                     style={{
                       fontFamily: "var(--mono)",
                       fontSize: "12px",
                       color: "var(--fg-dim)",
-                      gridTemplateColumns: "80px 1fr",
                     }}
                   >
                     <span style={{ color: "var(--fg-faint)" }}>
@@ -120,11 +107,11 @@ export default function FeaturedWork() {
                       {t(`studies.${i}.metaValue`)}
                     </span>
                   </div>
-                  <div className="flex flex-wrap gap-[6px] mt-[6px]">
+                  <div className="flex flex-wrap gap-1.5 mt-1.5">
                     {study.pills.map((pill) => (
                       <span
                         key={pill}
-                        className="border rounded-[2px] px-[8px] py-[3px]"
+                        className="border rounded-sm px-2 py-0.5"
                         style={{
                           fontFamily: "var(--mono)",
                           fontSize: "10.5px",
@@ -139,11 +126,11 @@ export default function FeaturedWork() {
                 </div>
 
                 {/* Content */}
-                <div className="flex flex-col gap-[22px]">
+                <div className="flex flex-col gap-5">
                   <h3
                     style={{
                       fontFamily: "var(--serif)",
-                      fontSize: "30px",
+                      fontSize: "clamp(22px, 3vw, 30px)",
                       fontWeight: 400,
                       letterSpacing: "-0.01em",
                       lineHeight: 1.15,
@@ -157,7 +144,7 @@ export default function FeaturedWork() {
 
                   <div>
                     <div
-                      className="flex items-center gap-[8px] mb-[6px]"
+                      className="flex items-center gap-2 mb-1.5"
                       style={{
                         fontFamily: "var(--mono)",
                         fontSize: "11px",
@@ -182,7 +169,7 @@ export default function FeaturedWork() {
 
                   <div>
                     <div
-                      className="flex items-center gap-[8px] mb-[6px]"
+                      className="flex items-center gap-2 mb-1.5"
                       style={{
                         fontFamily: "var(--mono)",
                         fontSize: "11px",
@@ -206,9 +193,8 @@ export default function FeaturedWork() {
                   </div>
 
                   <div
-                    className="grid gap-[22px] items-center rounded-[4px] p-[18px] pr-[20px]"
+                    className="outcome-grid rounded p-4"
                     style={{
-                      gridTemplateColumns: "auto 1fr",
                       background: "var(--bg-2)",
                       border: "1px solid var(--line)",
                     }}
@@ -217,7 +203,7 @@ export default function FeaturedWork() {
                       <div
                         style={{
                           fontFamily: "var(--serif)",
-                          fontSize: "64px",
+                          fontSize: "clamp(40px, 5vw, 64px)",
                           lineHeight: 0.9,
                           color: "var(--accent)",
                           letterSpacing: "-0.03em",
@@ -229,7 +215,7 @@ export default function FeaturedWork() {
                         />
                       </div>
                       <div
-                        className="mt-[4px]"
+                        className="mt-1"
                         style={{
                           fontFamily: "var(--mono)",
                           fontSize: "11px",
@@ -257,7 +243,7 @@ export default function FeaturedWork() {
                       href={study.link.href}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-[6px] self-start no-underline hover:border-solid"
+                      className="inline-flex items-center gap-1.5 self-start no-underline"
                       style={{
                         fontFamily: "var(--mono)",
                         fontSize: "12px",
@@ -270,16 +256,6 @@ export default function FeaturedWork() {
                   )}
                 </div>
               </div>
-
-              <style jsx>{`
-                @media (max-width: 1080px) {
-                  article > div:last-child {
-                    grid-template-columns: 1fr !important;
-                    gap: 24px !important;
-                    padding: 28px 20px 32px !important;
-                  }
-                }
-              `}</style>
             </article>
           </FadeIn>
         ))}

--- a/src/components/FeaturedWork.tsx
+++ b/src/components/FeaturedWork.tsx
@@ -3,24 +3,28 @@
 import { useTranslations } from "next-intl";
 import FadeIn from "./FadeIn";
 import CountUp from "./CountUp";
+import SectionHeader from "./SectionHeader";
 
 const caseStudyData = [
   {
-    index: "01",
+    index: 0,
+    lineStart: "001",
     resultNumber: 56,
     resultSuffix: "%",
     pills: ["Next.js", "Python", "Temporal", "AWS", "GraphQL"],
     link: null,
   },
   {
-    index: "02",
+    index: 1,
+    lineStart: "013",
     resultNumber: 10,
     resultSuffix: "yr",
     pills: ["React", "Node.js", "Go", "AWS Lambda", "Security"],
-    link: { href: "https://jira.atlassian.com/browse/AX-662" },
+    link: { href: "https://jira.atlassian.com/browse/CLOUD-6999" },
   },
   {
-    index: "03",
+    index: 2,
+    lineStart: "025",
     resultNumber: 30,
     resultSuffix: "d",
     pills: ["React", "Node.js", "APIs", "Payments", "Startup"],
@@ -32,102 +36,253 @@ export default function FeaturedWork() {
   const t = useTranslations("FeaturedWork");
 
   return (
-    <section id="work" className="relative py-32">
-      <div className="max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-6">
-            {t("heading")}
-          </h2>
-          <p className="font-[family-name:var(--font-inter)] text-on-surface-variant mb-20 max-w-xl">
-            {t("subheading")}
-          </p>
-        </FadeIn>
+    <section id="work">
+      <SectionHeader
+        idx="01"
+        file="selected_work.md"
+        title={t("heading")}
+        lede={t("subheading")}
+      />
 
-        <div className="space-y-24">
-          {caseStudyData.map((study, i) => (
-            <FadeIn key={study.index} delay={i * 100}>
-              <article className="relative">
-                <span className="font-[family-name:var(--font-manrope)] text-7xl sm:text-8xl font-bold text-surface-bright/50 absolute -top-10 -left-2 select-none pointer-events-none">
-                  {study.index}
-                </span>
+      <div className="border-t border-line">
+        {caseStudyData.map((study, i) => (
+          <FadeIn key={study.index}>
+            <article
+              className="grid border-b border-line relative transition-colors duration-200 hover:bg-accent/[0.02] group"
+              style={{ gridTemplateColumns: "56px 1fr" }}
+            >
+              {/* Year tick */}
+              <div
+                className="absolute left-[-1px] top-[36px] w-[2px] bg-accent transition-all duration-300"
+                style={{ height: 0 }}
+              />
 
-                <div className="relative pt-8">
-                  <div className="flex flex-wrap items-baseline gap-3 mb-2">
-                    <span className="font-[family-name:var(--font-inter)] text-xs tracking-[0.15em] uppercase text-primary">
-                      {t(`studies.${i}.company`)}
+              {/* Line numbers */}
+              <div
+                className="text-right py-[36px] px-[12px] select-none border-r border-line"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  color: "var(--fg-faint)",
+                }}
+              >
+                {study.lineStart}
+              </div>
+
+              {/* Body */}
+              <div
+                className="p-[36px] pb-[40px] grid gap-[48px]"
+                style={{ gridTemplateColumns: "1fr 1.3fr" }}
+              >
+                {/* Meta */}
+                <div className="flex flex-col gap-[16px]">
+                  <div
+                    style={{
+                      fontFamily: "var(--serif)",
+                      fontSize: "48px",
+                      letterSpacing: "-0.02em",
+                      lineHeight: 1,
+                    }}
+                  >
+                    {t(`studies.${i}.company`)}
+                  </div>
+                  <div
+                    className="grid gap-y-[6px] gap-x-[14px]"
+                    style={{
+                      fontFamily: "var(--mono)",
+                      fontSize: "12px",
+                      color: "var(--fg-dim)",
+                      gridTemplateColumns: "80px 1fr",
+                    }}
+                  >
+                    <span style={{ color: "var(--fg-faint)" }}>
+                      {t("yearLabel")}
                     </span>
-                    <span className="font-[family-name:var(--font-inter)] text-xs text-on-surface-variant/40">
+                    <span style={{ color: "var(--fg)" }}>
                       {t(`studies.${i}.period`)}
                     </span>
+                    <span style={{ color: "var(--fg-faint)" }}>
+                      {t("roleLabel")}
+                    </span>
+                    <span style={{ color: "var(--fg)" }}>
+                      {t(`studies.${i}.role`)}
+                    </span>
+                    <span style={{ color: "var(--fg-faint)" }}>
+                      {t("teamLabel")}
+                    </span>
+                    <span style={{ color: "var(--fg)" }}>
+                      {t(`studies.${i}.team`)}
+                    </span>
+                    <span style={{ color: "var(--fg-faint)" }}>
+                      {t(`studies.${i}.metaLabel`)}
+                    </span>
+                    <span style={{ color: "var(--accent)" }}>
+                      {t(`studies.${i}.metaValue`)}
+                    </span>
                   </div>
-
-                  <h3 className="font-[family-name:var(--font-manrope)] text-2xl sm:text-3xl font-bold mb-8 leading-tight">
-                    {t(`studies.${i}.title`)}
-                  </h3>
-
-                  <div className="grid sm:grid-cols-[1fr_1fr] gap-8 mb-8">
-                    <div>
-                      <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.15em] uppercase text-on-surface-variant/50 mb-2">
-                        {t("theProblem")}
-                      </p>
-                      <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                        {t(`studies.${i}.problem`)}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.15em] uppercase text-on-surface-variant/50 mb-2">
-                        {t("myRole")}
-                      </p>
-                      <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                        {t(`studies.${i}.approach`)}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="bg-surface-low rounded-xl p-6 ghost-border">
-                    <div className="flex items-start gap-6">
-                      <div className="text-center shrink-0">
-                        <p className="font-[family-name:var(--font-manrope)] text-4xl font-bold text-primary">
-                          <CountUp end={study.resultNumber} suffix={study.resultSuffix} />
-                        </p>
-                        <p className="font-[family-name:var(--font-inter)] text-xs text-on-surface-variant/60 mt-1">
-                          {t(`studies.${i}.resultLabel`)}
-                        </p>
-                      </div>
-                      <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                        {t(`studies.${i}.result`)}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap items-center gap-2 mt-6">
+                  <div className="flex flex-wrap gap-[6px] mt-[6px]">
                     {study.pills.map((pill) => (
                       <span
                         key={pill}
-                        className="text-xs font-[family-name:var(--font-inter)] px-3 py-1 rounded-full bg-surface-bright/40 text-on-surface-variant/70"
+                        className="border rounded-[2px] px-[8px] py-[3px]"
+                        style={{
+                          fontFamily: "var(--mono)",
+                          fontSize: "10.5px",
+                          color: "var(--fg-dim)",
+                          borderColor: "var(--line-strong)",
+                        }}
                       >
                         {pill}
                       </span>
                     ))}
-                    {study.link && (
-                      <a
-                        href={study.link.href}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs font-[family-name:var(--font-inter)] text-primary hover:text-secondary transition-colors ml-2"
-                      >
-                        {t(`studies.${i}.linkLabel`)} &rarr;
-                      </a>
-                    )}
                   </div>
                 </div>
-              </article>
-            </FadeIn>
-          ))}
-        </div>
+
+                {/* Content */}
+                <div className="flex flex-col gap-[22px]">
+                  <h3
+                    style={{
+                      fontFamily: "var(--serif)",
+                      fontSize: "30px",
+                      fontWeight: 400,
+                      letterSpacing: "-0.01em",
+                      lineHeight: 1.15,
+                      color: "var(--fg)",
+                      marginBottom: "4px",
+                    }}
+                    dangerouslySetInnerHTML={{
+                      __html: t.raw(`studies.${i}.title`),
+                    }}
+                  />
+
+                  <div>
+                    <div
+                      className="flex items-center gap-[8px] mb-[6px]"
+                      style={{
+                        fontFamily: "var(--mono)",
+                        fontSize: "11px",
+                        color: "var(--fg-faint)",
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      <span style={{ color: "var(--accent)" }}>#</span>
+                      {t("theProblem")}
+                    </div>
+                    <p
+                      style={{
+                        color: "var(--fg-dim)",
+                        fontSize: "15px",
+                        lineHeight: 1.65,
+                      }}
+                    >
+                      {t(`studies.${i}.problem`)}
+                    </p>
+                  </div>
+
+                  <div>
+                    <div
+                      className="flex items-center gap-[8px] mb-[6px]"
+                      style={{
+                        fontFamily: "var(--mono)",
+                        fontSize: "11px",
+                        color: "var(--fg-faint)",
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                      }}
+                    >
+                      <span style={{ color: "var(--accent)" }}>#</span>
+                      {t("myRole")}
+                    </div>
+                    <p
+                      style={{
+                        color: "var(--fg-dim)",
+                        fontSize: "15px",
+                        lineHeight: 1.65,
+                      }}
+                    >
+                      {t(`studies.${i}.approach`)}
+                    </p>
+                  </div>
+
+                  <div
+                    className="grid gap-[22px] items-center rounded-[4px] p-[18px] pr-[20px]"
+                    style={{
+                      gridTemplateColumns: "auto 1fr",
+                      background: "var(--bg-2)",
+                      border: "1px solid var(--line)",
+                    }}
+                  >
+                    <div>
+                      <div
+                        style={{
+                          fontFamily: "var(--serif)",
+                          fontSize: "64px",
+                          lineHeight: 0.9,
+                          color: "var(--accent)",
+                          letterSpacing: "-0.03em",
+                        }}
+                      >
+                        <CountUp
+                          end={study.resultNumber}
+                          suffix={study.resultSuffix}
+                        />
+                      </div>
+                      <div
+                        className="mt-[4px]"
+                        style={{
+                          fontFamily: "var(--mono)",
+                          fontSize: "11px",
+                          color: "var(--fg-faint)",
+                          textTransform: "uppercase",
+                          letterSpacing: "0.08em",
+                        }}
+                      >
+                        {t(`studies.${i}.resultLabel`)}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        color: "var(--fg)",
+                        fontSize: "14px",
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      {t(`studies.${i}.result`)}
+                    </div>
+                  </div>
+
+                  {study.link && (
+                    <a
+                      href={study.link.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-[6px] self-start no-underline hover:border-solid"
+                      style={{
+                        fontFamily: "var(--mono)",
+                        fontSize: "12px",
+                        color: "var(--accent)",
+                        borderBottom: "1px dashed rgba(232,162,83,0.4)",
+                      }}
+                    >
+                      {t(`studies.${i}.linkLabel`)} <span>↗</span>
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              <style jsx>{`
+                @media (max-width: 1080px) {
+                  article > div:last-child {
+                    grid-template-columns: 1fr !important;
+                    gap: 24px !important;
+                    padding: 28px 20px 32px !important;
+                  }
+                }
+              `}</style>
+            </article>
+          </FadeIn>
+        ))}
       </div>
     </section>
   );

--- a/src/components/FeaturedWork.tsx
+++ b/src/components/FeaturedWork.tsx
@@ -44,7 +44,7 @@ export default function FeaturedWork() {
         lede={t("subheading")}
       />
 
-      <div className="border-t border-line">
+      <div className="wrap border-t border-line">
         {caseStudyData.map((study, i) => (
           <FadeIn key={study.index}>
             <article className="project-grid border-b border-line relative transition-colors duration-200 hover:bg-accent/[0.02]">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,38 +6,24 @@ export default function Footer() {
   const t = useTranslations("Footer");
 
   return (
-    <footer className="py-12 border-t border-outline-variant/10">
-      <div className="max-w-7xl mx-auto px-6 flex flex-col items-center gap-6">
-        {/* Social */}
-        <div className="flex gap-6">
-          <a
-            href="https://linkedin.com/in/juan-murillo"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-on-surface-variant/50 hover:text-primary transition-colors"
-            aria-label="LinkedIn"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
-            </svg>
-          </a>
-          <a
-            href="https://github.com/jgmurillo10"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-on-surface-variant/50 hover:text-primary transition-colors"
-            aria-label="GitHub"
-          >
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-            </svg>
-          </a>
-        </div>
-
-        {/* Copyright */}
-        <p className="font-[family-name:var(--font-inter)] text-xs text-on-surface-variant/40">
-          &copy; {new Date().getFullYear()} {t("copyright")}
-        </p>
+    <footer
+      className="border-t border-line flex justify-between gap-[20px] flex-wrap"
+      style={{
+        padding: "20px 28px",
+        fontFamily: "var(--mono)",
+        fontSize: "11.5px",
+        color: "var(--fg-faint)",
+      }}
+    >
+      <div className="flex items-center gap-[8px]">
+        <span
+          className="w-[6px] h-[6px] rounded-full"
+          style={{ background: "var(--green)" }}
+        />
+        {t("location")}
+      </div>
+      <div>
+        &copy; {new Date().getFullYear()} {t("copyright")}
       </div>
     </footer>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -7,7 +7,7 @@ export default function Footer() {
 
   return (
     <footer
-      className="border-t border-line flex justify-between gap-[20px] flex-wrap"
+      className="border-t border-line"
       style={{
         padding: "20px 28px",
         fontFamily: "var(--mono)",
@@ -15,7 +15,8 @@ export default function Footer() {
         color: "var(--fg-faint)",
       }}
     >
-      <div className="flex items-center gap-[8px]">
+      <div className="wrap flex justify-between gap-5 flex-wrap" style={{ paddingTop: "20px", paddingBottom: "20px" }}>
+      <div className="flex items-center gap-2">
         <span
           className="w-[6px] h-[6px] rounded-full"
           style={{ background: "var(--green)" }}
@@ -24,6 +25,7 @@ export default function Footer() {
       </div>
       <div>
         &copy; {new Date().getFullYear()} {t("copyright")}
+      </div>
       </div>
     </footer>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,165 +1,319 @@
 "use client";
 
-import Image from "next/image";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 
 export default function Hero() {
   const t = useTranslations("Hero");
-  const roles = [t("roles.0"), t("roles.1"), t("roles.2"), t("roles.3"), t("roles.4")];
+  const [typedText, setTypedText] = useState("'leading AI automation at Snappr'");
 
-  const [roleIndex, setRoleIndex] = useState(0);
-  const [fade, setFade] = useState(true);
-  const [mousePos, setMousePos] = useState({ x: 0, y: 0 });
-  const [isHovering, setIsHovering] = useState(false);
-  const sectionRef = useRef<HTMLElement>(null);
-
-  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    setMousePos({
-      x: e.clientX - rect.left,
-      y: e.clientY - rect.top,
-    });
-  }, []);
-
-  const handleMouseEnter = useCallback(() => setIsHovering(true), []);
-  const handleMouseLeave = useCallback(() => setIsHovering(false), []);
+  const items = [
+    t("currently.0"),
+    t("currently.1"),
+    t("currently.2"),
+    t("currently.3"),
+    t("currently.4"),
+  ];
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setFade(false);
-      setTimeout(() => {
-        setRoleIndex((prev) => (prev + 1) % roles.length);
-        setFade(true);
-      }, 300);
-    }, 2800);
-    return () => clearInterval(interval);
-  }, [roles.length]);
+    let idx = 0;
+    let charIdx = items[0].length;
+    let dir: 1 | -1 = -1;
+    let timeout: ReturnType<typeof setTimeout>;
+
+    function tick() {
+      const full = items[idx];
+      if (dir === 1) {
+        charIdx++;
+        setTypedText(full.slice(0, charIdx));
+        if (charIdx >= full.length) {
+          dir = -1;
+          timeout = setTimeout(tick, 2200);
+          return;
+        }
+      } else {
+        charIdx--;
+        setTypedText(full.slice(0, charIdx));
+        if (charIdx <= 0) {
+          dir = 1;
+          idx = (idx + 1) % items.length;
+        }
+      }
+      timeout = setTimeout(tick, dir === 1 ? 55 : 28);
+    }
+
+    timeout = setTimeout(tick, 2200);
+    return () => clearTimeout(timeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <section
-      ref={sectionRef}
-      onMouseMove={handleMouseMove}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      className="relative min-h-screen flex items-center pt-16 overflow-hidden"
+      id="top"
+      className="relative min-h-[calc(100vh-90px)] px-[28px] py-[48px] pb-[64px] grid gap-[48px] items-end"
+      style={{
+        gridTemplateColumns: "1fr 420px",
+      }}
     >
-      {/* Aurora background */}
-      <div className="absolute inset-0 pointer-events-none overflow-hidden">
-        <div className="aurora-blob absolute top-[15%] left-[10%] w-[500px] h-[500px] bg-primary-dim/8 rounded-full blur-[100px]" />
-        <div className="aurora-blob-2 absolute top-[40%] right-[5%] w-[400px] h-[350px] bg-secondary/5 rounded-full blur-[120px]" />
-        <div className="aurora-blob-3 absolute bottom-[10%] left-[30%] w-[350px] h-[300px] bg-primary/4 rounded-full blur-[100px]" />
-        {/* Fade to background at bottom */}
-        <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-b from-transparent to-background" />
-      </div>
-
-      {/* Mouse-follow spotlight */}
+      {/* Grid background */}
       <div
-        className="absolute inset-0 pointer-events-none transition-opacity duration-500"
+        className="absolute inset-0 pointer-events-none"
         style={{
-          opacity: isHovering ? 0.08 : 0,
-          background: `radial-gradient(600px circle at ${mousePos.x}px ${mousePos.y}px, var(--color-primary-dim), transparent 60%)`,
+          backgroundImage: `linear-gradient(var(--line) 1px, transparent 1px), linear-gradient(90deg, var(--line) 1px, transparent 1px)`,
+          backgroundSize: "80px 80px",
+          maskImage:
+            "radial-gradient(ellipse at center, black 30%, transparent 75%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse at center, black 30%, transparent 75%)",
         }}
       />
 
-      <div className="relative max-w-7xl mx-auto px-6 py-20 w-full">
-        {/* Mobile photo - shown above copy on small screens */}
-        <div className="md:hidden flex justify-center mb-10">
-          <div className="rotating-border w-40 aspect-square rounded-2xl overflow-hidden bg-surface-low">
-            <Image
-              src="/juan-murillo.jpg"
-              alt="Juan Murillo"
-              width={160}
-              height={160}
-              className="object-cover w-full h-full"
-              priority
-            />
-          </div>
+      {/* Left content */}
+      <div className="relative z-[2]">
+        <div
+          className="mb-[28px] flex items-center gap-[10px]"
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "12px",
+            color: "var(--fg-faint)",
+          }}
+        >
+          <span
+            className="border rounded-[3px] px-[8px] py-[3px]"
+            style={{
+              borderColor: "var(--line-strong)",
+              color: "var(--fg-dim)",
+            }}
+          >
+            <span style={{ color: "var(--green)" }}>●</span>{" "}
+            {t("statusBadge")}
+          </span>
+          <span>/</span>
+          <span>{t("roleLine")}</span>
         </div>
 
-        <div className="grid md:grid-cols-[1fr_auto] gap-12 lg:gap-20 items-center">
+        <h1
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: "clamp(48px, 7.4vw, 112px)",
+            lineHeight: 0.98,
+            letterSpacing: "-0.025em",
+            maxWidth: "18ch",
+            textWrap: "balance",
+          }}
+        >
+          {t("headlinePre")}{" "}
+          <span className="italic" style={{ color: "var(--accent)" }}>
+            {t("name")}
+          </span>
+          .<br />
+          {t("headlineMid")}{" "}
+          <span className="relative inline-block">
+            {t("headlineUnderline")}
+            <span
+              className="absolute left-0 right-0 bottom-[0.08em] h-[0.06em]"
+              style={{ background: "var(--accent)", opacity: 0.5 }}
+            />
+          </span>
+          <br />
+          {t("headlineEnd")}{" "}
+          <span className="italic" style={{ color: "var(--accent)" }}>
+            {t("headlineAccent")}
+          </span>
+          .
+        </h1>
+
+        {/* Code block */}
+        <div
+          className="mt-[36px] max-w-[52ch]"
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "14px",
+            color: "var(--fg-dim)",
+            lineHeight: 1.7,
+          }}
+        >
           <div>
-            <p className="font-[family-name:var(--font-inter)] text-on-surface-variant mb-6 leading-relaxed">
-              {t("greeting")} <strong className="text-on-surface">{t("name")}</strong>,{" "}
-              <span
-                className="text-primary inline-block min-w-[200px] transition-all duration-300"
-                style={{
-                  opacity: fade ? 1 : 0,
-                  transform: fade ? "translateY(0)" : "translateY(6px)",
-                }}
-              >
-                {roles[roleIndex]}
-              </span>
-              <br className="hidden sm:block" />
-              {t("basedIn")}
-            </p>
-
-            <h1 className="font-[family-name:var(--font-manrope)] text-4xl sm:text-5xl lg:text-6xl font-bold leading-[1.08] mb-8 tracking-tight">
-              {t("headlineLine1")}
-              <br className="hidden sm:block" />
-              {t("headlineLine2")}
-              <br className="hidden sm:block" />
-              {t("headlineLine3")} <span className="text-primary">{t("headlineHighlight")}</span>
-            </h1>
-
-            <div className="font-[family-name:var(--font-inter)] text-base text-on-surface-variant max-w-xl leading-relaxed space-y-4 mb-10">
-              <p>
-                {t("bodyParagraph1Start")}{" "}
-                <strong className="text-on-surface">{t("bodyAtlassian")}</strong>
-                {t("bodyAtlassianText")}{" "}
-                <a
-                  href="https://jira.atlassian.com/browse/AX-662"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:text-secondary transition-colors underline underline-offset-2"
-                >
-                  {t("bodyAtlassianTicket")}
-                </a>
-                {t("bodyAtlassianAfterTicket")}{" "}
-                <strong className="text-on-surface">{t("bodySnappr")}</strong>
-                {t("bodySnapprText")}{" "}
-                <strong className="text-on-surface">{t("bodyGoogle")}</strong>
-                {t("bodyGoogleText")}
-              </p>
-              <p>
-                {t("bodyParagraph2Start")}{" "}
-                <strong className="text-on-surface">{t("bodyCoffeeStartup")}</strong>{" "}
-                {t("bodyParagraph2End")}
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-3">
-              <a
-                href="#work"
-                className="gradient-btn text-black font-medium font-[family-name:var(--font-inter)] px-6 py-3 rounded-lg hover:opacity-90 transition-opacity text-sm"
-              >
-                {t("ctaWork")}
-              </a>
-              <a
-                href="#contact"
-                className="ghost-border text-on-surface-variant font-medium font-[family-name:var(--font-inter)] px-6 py-3 rounded-lg hover:text-on-surface hover:bg-surface-highest/40 transition-colors text-sm"
-              >
-                {t("ctaHello")}
-              </a>
-            </div>
+            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+              ❯
+            </span>
+            <span style={{ color: "var(--blue)" }}>const</span>{" "}
+            <span style={{ color: "var(--fg)" }}>engineer</span> = {"{"}
           </div>
+          <div>
+            &nbsp;&nbsp;based_in:{" "}
+            <span style={{ color: "var(--green)" }}>
+              &apos;{t("basedIn")}&apos;
+            </span>
+            ,
+          </div>
+          <div>
+            &nbsp;&nbsp;obsessions: [
+            <span style={{ color: "var(--green)" }}>&apos;AI&apos;</span>,{" "}
+            <span style={{ color: "var(--green)" }}>
+              &apos;complex problems&apos;
+            </span>
+            ,{" "}
+            <span style={{ color: "var(--green)" }}>&apos;coffee&apos;</span>
+            ],
+          </div>
+          <div>
+            &nbsp;&nbsp;currently:{" "}
+            <span style={{ color: "var(--green)" }}>{typedText}</span>
+            <span
+              className="inline-block w-[8px] h-[16px] align-text-bottom ml-[2px] blink"
+              style={{ background: "var(--accent)" }}
+            />
+          </div>
+          <div>{"}"}</div>
+        </div>
 
-          {/* Desktop photo with rotating gradient border */}
-          <div className="hidden md:block relative">
-            <div className="rotating-border w-72 lg:w-80 aspect-[3/4] rounded-2xl overflow-hidden bg-surface-low">
-              <Image
-                src="/juan-murillo.jpg"
-                alt="Juan Murillo"
-                width={320}
-                height={427}
-                className="object-cover w-full h-full grayscale hover:grayscale-0 transition-all duration-700"
-                priority
-              />
-            </div>
-            <div className="aurora-blob absolute -inset-8 -z-10 bg-primary-dim/10 rounded-3xl blur-3xl" />
+        <div className="mt-[42px] flex gap-[14px] items-center flex-wrap">
+          <a
+            href="#work"
+            className="inline-flex items-center gap-[10px] rounded-[3px] no-underline transition-transform duration-150 hover:-translate-y-px"
+            style={{
+              background: "var(--fg)",
+              color: "var(--bg)",
+              fontFamily: "var(--mono)",
+              fontSize: "12px",
+              fontWeight: 600,
+              padding: "11px 18px",
+            }}
+          >
+            {t("ctaWork")} <span>→</span>
+          </a>
+          <a
+            href="#contact"
+            className="inline-flex items-center gap-[10px] rounded-[3px] border no-underline transition-all duration-150 hover:-translate-y-px"
+            style={{
+              background: "transparent",
+              borderColor: "var(--line-strong)",
+              color: "var(--fg)",
+              fontFamily: "var(--mono)",
+              fontSize: "12px",
+              padding: "11px 18px",
+            }}
+          >
+            {t("ctaHello")} <span>↗</span>
+          </a>
+        </div>
+      </div>
+
+      {/* Terminal card */}
+      <div
+        className="relative z-[2] rounded-[6px] overflow-hidden hidden xl:block"
+        style={{
+          background: "var(--bg-2)",
+          border: "1px solid var(--line-strong)",
+          fontFamily: "var(--mono)",
+          fontSize: "12.5px",
+          boxShadow:
+            "0 30px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(232,162,83,0.03)",
+        }}
+        aria-hidden="true"
+      >
+        <div
+          className="flex items-center gap-[8px] px-[14px] py-[10px] border-b"
+          style={{
+            borderColor: "var(--line)",
+            background: "rgba(255,255,255,0.015)",
+          }}
+        >
+          <span className="w-[10px] h-[10px] rounded-full bg-[#E5564E]" />
+          <span className="w-[10px] h-[10px] rounded-full bg-[#E0B13F]" />
+          <span className="w-[10px] h-[10px] rounded-full bg-[#5EC37A]" />
+          <span
+            className="ml-auto"
+            style={{ color: "var(--fg-faint)", fontSize: "11px" }}
+          >
+            ~/juan · whoami
+          </span>
+        </div>
+        <div className="p-[18px] pb-[20px]">
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+              ❯
+            </span>
+            whoami --verbose
+          </div>
+          <div style={{ color: "var(--fg-faint)", lineHeight: 1.75 }}>
+            # {t("termTitle")}
+          </div>
+          <hr
+            className="border-0 border-t border-dashed my-[10px]"
+            style={{ borderColor: "var(--line)" }}
+          />
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--blue)" }}>stack</span>:{" "}
+            <span style={{ color: "var(--fg)" }}>
+              react · node · python · go
+            </span>
+          </div>
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--blue)" }}>infra</span>:{" "}
+            <span style={{ color: "var(--fg)" }}>
+              aws · gcp · temporal · docker
+            </span>
+          </div>
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--blue)" }}>ai</span>:{" "}
+            <span style={{ color: "var(--fg)" }}>
+              pytorch · grpo · llm agents
+            </span>
+          </div>
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--blue)" }}>teams</span>:{" "}
+            <span style={{ color: "var(--fg)" }}>
+              {t("termTeams")}
+            </span>
+          </div>
+          <hr
+            className="border-0 border-t border-dashed my-[10px]"
+            style={{ borderColor: "var(--line)" }}
+          />
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+              ❯
+            </span>
+            cat achievements.md | tail -3
+          </div>
+          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+            ✓ CLOUD-6999 closed after 10+ years
+          </div>
+          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+            ✓ Food imagery automated 0% → 56%
+          </div>
+          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+            ✓ YC interview in under 30 days
+          </div>
+          <hr
+            className="border-0 border-t border-dashed my-[10px]"
+            style={{ borderColor: "var(--line)" }}
+          />
+          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+              ❯
+            </span>
+            <span className="blink">_</span>
           </div>
         </div>
       </div>
+
+      {/* Responsive: hide terminal card on smaller screens */}
+      <style jsx>{`
+        @media (max-width: 1080px) {
+          section {
+            grid-template-columns: 1fr !important;
+          }
+        }
+        @media (max-width: 640px) {
+          section h1 {
+            font-size: 52px !important;
+          }
+        }
+      `}</style>
     </section>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,9 @@ import { useTranslations } from "next-intl";
 
 export default function Hero() {
   const t = useTranslations("Hero");
-  const [typedText, setTypedText] = useState("'leading AI automation at Snappr'");
+  const [typedText, setTypedText] = useState(
+    "'leading AI automation at Snappr'"
+  );
 
   const items = [
     t("currently.0"),
@@ -48,10 +50,7 @@ export default function Hero() {
   }, []);
 
   return (
-    <section
-      id="top"
-      className="hero-grid relative min-h-[calc(100vh-90px)] px-[28px] py-[48px] pb-[64px]"
-    >
+    <section id="top" className="relative">
       {/* Grid background */}
       <div
         className="absolute inset-0 pointer-events-none"
@@ -65,232 +64,234 @@ export default function Hero() {
         }}
       />
 
-      {/* Left content */}
-      <div className="relative z-[2]">
-        <div
-          className="mb-7 flex items-center gap-2.5 flex-wrap"
-          style={{
-            fontFamily: "var(--mono)",
-            fontSize: "12px",
-            color: "var(--fg-faint)",
-          }}
-        >
-          <span
-            className="border rounded px-2 py-0.5"
+      <div className="wrap hero-grid min-h-[calc(100vh-90px)] py-12 pb-16">
+        {/* Left content */}
+        <div className="relative z-[2]">
+          <div
+            className="mb-7 flex items-center gap-2.5 flex-wrap"
             style={{
-              borderColor: "var(--line-strong)",
+              fontFamily: "var(--mono)",
+              fontSize: "12px",
+              color: "var(--fg-faint)",
+            }}
+          >
+            <span
+              className="border rounded px-2 py-0.5"
+              style={{
+                borderColor: "var(--line-strong)",
+                color: "var(--fg-dim)",
+              }}
+            >
+              <span style={{ color: "var(--green)" }}>●</span>{" "}
+              {t("statusBadge")}
+            </span>
+            <span>/</span>
+            <span>{t("roleLine")}</span>
+          </div>
+
+          <h1
+            style={{
+              fontFamily: "var(--serif)",
+              fontWeight: 400,
+              fontSize: "clamp(42px, 7.4vw, 112px)",
+              lineHeight: 0.98,
+              letterSpacing: "-0.025em",
+              maxWidth: "18ch",
+            }}
+          >
+            {t("headlinePre")}{" "}
+            <span className="italic" style={{ color: "var(--accent)" }}>
+              {t("name")}
+            </span>
+            .<br />
+            {t("headlineMid")}{" "}
+            <span className="relative inline-block">
+              {t("headlineUnderline")}
+              <span
+                className="absolute left-0 right-0 bottom-[0.08em] h-[0.06em]"
+                style={{ background: "var(--accent)", opacity: 0.5 }}
+              />
+            </span>
+            <br />
+            {t("headlineEnd")}{" "}
+            <span className="italic" style={{ color: "var(--accent)" }}>
+              {t("headlineAccent")}
+            </span>
+            .
+          </h1>
+
+          {/* Code block */}
+          <div
+            className="mt-9 max-w-[52ch]"
+            style={{
+              fontFamily: "var(--mono)",
+              fontSize: "clamp(11px, 1.4vw, 14px)",
               color: "var(--fg-dim)",
+              lineHeight: 1.7,
             }}
           >
-            <span style={{ color: "var(--green)" }}>●</span>{" "}
-            {t("statusBadge")}
-          </span>
-          <span>/</span>
-          <span>{t("roleLine")}</span>
+            <div>
+              <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+                ❯
+              </span>
+              <span style={{ color: "var(--blue)" }}>const</span>{" "}
+              <span style={{ color: "var(--fg)" }}>engineer</span> = {"{"}
+            </div>
+            <div>
+              &nbsp;&nbsp;based_in:{" "}
+              <span style={{ color: "var(--green)" }}>
+                &apos;{t("basedIn")}&apos;
+              </span>
+              ,
+            </div>
+            <div>
+              &nbsp;&nbsp;obsessions: [
+              <span style={{ color: "var(--green)" }}>&apos;AI&apos;</span>,{" "}
+              <span style={{ color: "var(--green)" }}>
+                &apos;complex problems&apos;
+              </span>
+              ,{" "}
+              <span style={{ color: "var(--green)" }}>&apos;coffee&apos;</span>
+              ],
+            </div>
+            <div>
+              &nbsp;&nbsp;currently:{" "}
+              <span style={{ color: "var(--green)" }}>{typedText}</span>
+              <span
+                className="inline-block w-2 h-4 align-text-bottom ml-0.5 blink"
+                style={{ background: "var(--accent)" }}
+              />
+            </div>
+            <div>{"}"}</div>
+          </div>
+
+          <div className="mt-10 flex gap-3.5 items-center flex-wrap">
+            <a
+              href="#work"
+              className="inline-flex items-center gap-2.5 rounded no-underline transition-transform duration-150 hover:-translate-y-px"
+              style={{
+                background: "var(--fg)",
+                color: "var(--bg)",
+                fontFamily: "var(--mono)",
+                fontSize: "12px",
+                fontWeight: 600,
+                padding: "11px 18px",
+              }}
+            >
+              {t("ctaWork")} <span>→</span>
+            </a>
+            <a
+              href="#contact"
+              className="inline-flex items-center gap-2.5 rounded border no-underline transition-all duration-150 hover:-translate-y-px"
+              style={{
+                background: "transparent",
+                borderColor: "var(--line-strong)",
+                color: "var(--fg)",
+                fontFamily: "var(--mono)",
+                fontSize: "12px",
+                padding: "11px 18px",
+              }}
+            >
+              {t("ctaHello")} <span>↗</span>
+            </a>
+          </div>
         </div>
 
-        <h1
-          style={{
-            fontFamily: "var(--serif)",
-            fontWeight: 400,
-            fontSize: "clamp(42px, 7.4vw, 112px)",
-            lineHeight: 0.98,
-            letterSpacing: "-0.025em",
-            maxWidth: "18ch",
-          }}
-        >
-          {t("headlinePre")}{" "}
-          <span className="italic" style={{ color: "var(--accent)" }}>
-            {t("name")}
-          </span>
-          .<br />
-          {t("headlineMid")}{" "}
-          <span className="relative inline-block">
-            {t("headlineUnderline")}
-            <span
-              className="absolute left-0 right-0 bottom-[0.08em] h-[0.06em]"
-              style={{ background: "var(--accent)", opacity: 0.5 }}
-            />
-          </span>
-          <br />
-          {t("headlineEnd")}{" "}
-          <span className="italic" style={{ color: "var(--accent)" }}>
-            {t("headlineAccent")}
-          </span>
-          .
-        </h1>
-
-        {/* Code block */}
+        {/* Terminal card */}
         <div
-          className="mt-9 max-w-[52ch]"
+          className="relative z-[2] rounded-md overflow-hidden hidden xl:block"
           style={{
+            background: "var(--bg-2)",
+            border: "1px solid var(--line-strong)",
             fontFamily: "var(--mono)",
-            fontSize: "clamp(11px, 1.4vw, 14px)",
-            color: "var(--fg-dim)",
-            lineHeight: 1.7,
+            fontSize: "12.5px",
+            boxShadow:
+              "0 30px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(232,162,83,0.03)",
           }}
+          aria-hidden="true"
         >
-          <div>
-            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
-              ❯
-            </span>
-            <span style={{ color: "var(--blue)" }}>const</span>{" "}
-            <span style={{ color: "var(--fg)" }}>engineer</span> = {"{"}
-          </div>
-          <div>
-            &nbsp;&nbsp;based_in:{" "}
-            <span style={{ color: "var(--green)" }}>
-              &apos;{t("basedIn")}&apos;
-            </span>
-            ,
-          </div>
-          <div>
-            &nbsp;&nbsp;obsessions: [
-            <span style={{ color: "var(--green)" }}>&apos;AI&apos;</span>,{" "}
-            <span style={{ color: "var(--green)" }}>
-              &apos;complex problems&apos;
-            </span>
-            ,{" "}
-            <span style={{ color: "var(--green)" }}>&apos;coffee&apos;</span>
-            ],
-          </div>
-          <div>
-            &nbsp;&nbsp;currently:{" "}
-            <span style={{ color: "var(--green)" }}>{typedText}</span>
+          <div
+            className="flex items-center gap-2 px-3.5 py-2.5 border-b"
+            style={{
+              borderColor: "var(--line)",
+              background: "rgba(255,255,255,0.015)",
+            }}
+          >
+            <span className="w-2.5 h-2.5 rounded-full bg-[#E5564E]" />
+            <span className="w-2.5 h-2.5 rounded-full bg-[#E0B13F]" />
+            <span className="w-2.5 h-2.5 rounded-full bg-[#5EC37A]" />
             <span
-              className="inline-block w-2 h-4 align-text-bottom ml-0.5 blink"
-              style={{ background: "var(--accent)" }}
+              className="ml-auto"
+              style={{ color: "var(--fg-faint)", fontSize: "11px" }}
+            >
+              ~/juan · whoami
+            </span>
+          </div>
+          <div className="p-4 pb-5">
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+                ❯
+              </span>
+              whoami --verbose
+            </div>
+            <div style={{ color: "var(--fg-faint)", lineHeight: 1.75 }}>
+              # {t("termTitle")}
+            </div>
+            <hr
+              className="border-0 border-t border-dashed my-2.5"
+              style={{ borderColor: "var(--line)" }}
             />
-          </div>
-          <div>{"}"}</div>
-        </div>
-
-        <div className="mt-10 flex gap-3.5 items-center flex-wrap">
-          <a
-            href="#work"
-            className="inline-flex items-center gap-2.5 rounded no-underline transition-transform duration-150 hover:-translate-y-px"
-            style={{
-              background: "var(--fg)",
-              color: "var(--bg)",
-              fontFamily: "var(--mono)",
-              fontSize: "12px",
-              fontWeight: 600,
-              padding: "11px 18px",
-            }}
-          >
-            {t("ctaWork")} <span>→</span>
-          </a>
-          <a
-            href="#contact"
-            className="inline-flex items-center gap-2.5 rounded border no-underline transition-all duration-150 hover:-translate-y-px"
-            style={{
-              background: "transparent",
-              borderColor: "var(--line-strong)",
-              color: "var(--fg)",
-              fontFamily: "var(--mono)",
-              fontSize: "12px",
-              padding: "11px 18px",
-            }}
-          >
-            {t("ctaHello")} <span>↗</span>
-          </a>
-        </div>
-      </div>
-
-      {/* Terminal card */}
-      <div
-        className="relative z-[2] rounded-md overflow-hidden hidden xl:block"
-        style={{
-          background: "var(--bg-2)",
-          border: "1px solid var(--line-strong)",
-          fontFamily: "var(--mono)",
-          fontSize: "12.5px",
-          boxShadow:
-            "0 30px 80px rgba(0,0,0,0.5), 0 0 0 1px rgba(232,162,83,0.03)",
-        }}
-        aria-hidden="true"
-      >
-        <div
-          className="flex items-center gap-2 px-3.5 py-2.5 border-b"
-          style={{
-            borderColor: "var(--line)",
-            background: "rgba(255,255,255,0.015)",
-          }}
-        >
-          <span className="w-2.5 h-2.5 rounded-full bg-[#E5564E]" />
-          <span className="w-2.5 h-2.5 rounded-full bg-[#E0B13F]" />
-          <span className="w-2.5 h-2.5 rounded-full bg-[#5EC37A]" />
-          <span
-            className="ml-auto"
-            style={{ color: "var(--fg-faint)", fontSize: "11px" }}
-          >
-            ~/juan · whoami
-          </span>
-        </div>
-        <div className="p-4 pb-5">
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
-              ❯
-            </span>
-            whoami --verbose
-          </div>
-          <div style={{ color: "var(--fg-faint)", lineHeight: 1.75 }}>
-            # {t("termTitle")}
-          </div>
-          <hr
-            className="border-0 border-t border-dashed my-2.5"
-            style={{ borderColor: "var(--line)" }}
-          />
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--blue)" }}>stack</span>:{" "}
-            <span style={{ color: "var(--fg)" }}>
-              react · node · python · go
-            </span>
-          </div>
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--blue)" }}>infra</span>:{" "}
-            <span style={{ color: "var(--fg)" }}>
-              aws · gcp · temporal · docker
-            </span>
-          </div>
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--blue)" }}>ai</span>:{" "}
-            <span style={{ color: "var(--fg)" }}>
-              pytorch · grpo · llm agents
-            </span>
-          </div>
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--blue)" }}>teams</span>:{" "}
-            <span style={{ color: "var(--fg)" }}>{t("termTeams")}</span>
-          </div>
-          <hr
-            className="border-0 border-t border-dashed my-2.5"
-            style={{ borderColor: "var(--line)" }}
-          />
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
-              ❯
-            </span>
-            cat achievements.md | tail -3
-          </div>
-          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
-            ✓ CLOUD-6999 closed after 10+ years
-          </div>
-          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
-            ✓ Food imagery automated 0% → 56%
-          </div>
-          <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
-            ✓ YC interview in under 30 days
-          </div>
-          <hr
-            className="border-0 border-t border-dashed my-2.5"
-            style={{ borderColor: "var(--line)" }}
-          />
-          <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
-            <span style={{ color: "var(--accent)", marginRight: "8px" }}>
-              ❯
-            </span>
-            <span className="blink">_</span>
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--blue)" }}>stack</span>:{" "}
+              <span style={{ color: "var(--fg)" }}>
+                react · node · python · go
+              </span>
+            </div>
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--blue)" }}>infra</span>:{" "}
+              <span style={{ color: "var(--fg)" }}>
+                aws · gcp · temporal · docker
+              </span>
+            </div>
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--blue)" }}>ai</span>:{" "}
+              <span style={{ color: "var(--fg)" }}>
+                pytorch · grpo · llm agents
+              </span>
+            </div>
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--blue)" }}>teams</span>:{" "}
+              <span style={{ color: "var(--fg)" }}>{t("termTeams")}</span>
+            </div>
+            <hr
+              className="border-0 border-t border-dashed my-2.5"
+              style={{ borderColor: "var(--line)" }}
+            />
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+                ❯
+              </span>
+              cat achievements.md | tail -3
+            </div>
+            <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+              ✓ CLOUD-6999 closed after 10+ years
+            </div>
+            <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+              ✓ Food imagery automated 0% → 56%
+            </div>
+            <div style={{ color: "var(--green)", lineHeight: 1.75 }}>
+              ✓ YC interview in under 30 days
+            </div>
+            <hr
+              className="border-0 border-t border-dashed my-2.5"
+              style={{ borderColor: "var(--line)" }}
+            />
+            <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
+              <span style={{ color: "var(--accent)", marginRight: "8px" }}>
+                ❯
+              </span>
+              <span className="blink">_</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -50,10 +50,7 @@ export default function Hero() {
   return (
     <section
       id="top"
-      className="relative min-h-[calc(100vh-90px)] px-[28px] py-[48px] pb-[64px] grid gap-[48px] items-end"
-      style={{
-        gridTemplateColumns: "1fr 420px",
-      }}
+      className="hero-grid relative min-h-[calc(100vh-90px)] px-[28px] py-[48px] pb-[64px]"
     >
       {/* Grid background */}
       <div
@@ -71,7 +68,7 @@ export default function Hero() {
       {/* Left content */}
       <div className="relative z-[2]">
         <div
-          className="mb-[28px] flex items-center gap-[10px]"
+          className="mb-7 flex items-center gap-2.5 flex-wrap"
           style={{
             fontFamily: "var(--mono)",
             fontSize: "12px",
@@ -79,7 +76,7 @@ export default function Hero() {
           }}
         >
           <span
-            className="border rounded-[3px] px-[8px] py-[3px]"
+            className="border rounded px-2 py-0.5"
             style={{
               borderColor: "var(--line-strong)",
               color: "var(--fg-dim)",
@@ -96,11 +93,10 @@ export default function Hero() {
           style={{
             fontFamily: "var(--serif)",
             fontWeight: 400,
-            fontSize: "clamp(48px, 7.4vw, 112px)",
+            fontSize: "clamp(42px, 7.4vw, 112px)",
             lineHeight: 0.98,
             letterSpacing: "-0.025em",
             maxWidth: "18ch",
-            textWrap: "balance",
           }}
         >
           {t("headlinePre")}{" "}
@@ -126,10 +122,10 @@ export default function Hero() {
 
         {/* Code block */}
         <div
-          className="mt-[36px] max-w-[52ch]"
+          className="mt-9 max-w-[52ch]"
           style={{
             fontFamily: "var(--mono)",
-            fontSize: "14px",
+            fontSize: "clamp(11px, 1.4vw, 14px)",
             color: "var(--fg-dim)",
             lineHeight: 1.7,
           }}
@@ -162,17 +158,17 @@ export default function Hero() {
             &nbsp;&nbsp;currently:{" "}
             <span style={{ color: "var(--green)" }}>{typedText}</span>
             <span
-              className="inline-block w-[8px] h-[16px] align-text-bottom ml-[2px] blink"
+              className="inline-block w-2 h-4 align-text-bottom ml-0.5 blink"
               style={{ background: "var(--accent)" }}
             />
           </div>
           <div>{"}"}</div>
         </div>
 
-        <div className="mt-[42px] flex gap-[14px] items-center flex-wrap">
+        <div className="mt-10 flex gap-3.5 items-center flex-wrap">
           <a
             href="#work"
-            className="inline-flex items-center gap-[10px] rounded-[3px] no-underline transition-transform duration-150 hover:-translate-y-px"
+            className="inline-flex items-center gap-2.5 rounded no-underline transition-transform duration-150 hover:-translate-y-px"
             style={{
               background: "var(--fg)",
               color: "var(--bg)",
@@ -186,7 +182,7 @@ export default function Hero() {
           </a>
           <a
             href="#contact"
-            className="inline-flex items-center gap-[10px] rounded-[3px] border no-underline transition-all duration-150 hover:-translate-y-px"
+            className="inline-flex items-center gap-2.5 rounded border no-underline transition-all duration-150 hover:-translate-y-px"
             style={{
               background: "transparent",
               borderColor: "var(--line-strong)",
@@ -203,7 +199,7 @@ export default function Hero() {
 
       {/* Terminal card */}
       <div
-        className="relative z-[2] rounded-[6px] overflow-hidden hidden xl:block"
+        className="relative z-[2] rounded-md overflow-hidden hidden xl:block"
         style={{
           background: "var(--bg-2)",
           border: "1px solid var(--line-strong)",
@@ -215,15 +211,15 @@ export default function Hero() {
         aria-hidden="true"
       >
         <div
-          className="flex items-center gap-[8px] px-[14px] py-[10px] border-b"
+          className="flex items-center gap-2 px-3.5 py-2.5 border-b"
           style={{
             borderColor: "var(--line)",
             background: "rgba(255,255,255,0.015)",
           }}
         >
-          <span className="w-[10px] h-[10px] rounded-full bg-[#E5564E]" />
-          <span className="w-[10px] h-[10px] rounded-full bg-[#E0B13F]" />
-          <span className="w-[10px] h-[10px] rounded-full bg-[#5EC37A]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#E5564E]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#E0B13F]" />
+          <span className="w-2.5 h-2.5 rounded-full bg-[#5EC37A]" />
           <span
             className="ml-auto"
             style={{ color: "var(--fg-faint)", fontSize: "11px" }}
@@ -231,7 +227,7 @@ export default function Hero() {
             ~/juan · whoami
           </span>
         </div>
-        <div className="p-[18px] pb-[20px]">
+        <div className="p-4 pb-5">
           <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
             <span style={{ color: "var(--accent)", marginRight: "8px" }}>
               ❯
@@ -242,7 +238,7 @@ export default function Hero() {
             # {t("termTitle")}
           </div>
           <hr
-            className="border-0 border-t border-dashed my-[10px]"
+            className="border-0 border-t border-dashed my-2.5"
             style={{ borderColor: "var(--line)" }}
           />
           <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
@@ -265,12 +261,10 @@ export default function Hero() {
           </div>
           <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
             <span style={{ color: "var(--blue)" }}>teams</span>:{" "}
-            <span style={{ color: "var(--fg)" }}>
-              {t("termTeams")}
-            </span>
+            <span style={{ color: "var(--fg)" }}>{t("termTeams")}</span>
           </div>
           <hr
-            className="border-0 border-t border-dashed my-[10px]"
+            className="border-0 border-t border-dashed my-2.5"
             style={{ borderColor: "var(--line)" }}
           />
           <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
@@ -289,7 +283,7 @@ export default function Hero() {
             ✓ YC interview in under 30 days
           </div>
           <hr
-            className="border-0 border-t border-dashed my-[10px]"
+            className="border-0 border-t border-dashed my-2.5"
             style={{ borderColor: "var(--line)" }}
           />
           <div style={{ color: "var(--fg-dim)", lineHeight: 1.75 }}>
@@ -300,20 +294,6 @@ export default function Hero() {
           </div>
         </div>
       </div>
-
-      {/* Responsive: hide terminal card on smaller screens */}
-      <style jsx>{`
-        @media (max-width: 1080px) {
-          section {
-            grid-template-columns: 1fr !important;
-          }
-        }
-        @media (max-width: 640px) {
-          section h1 {
-            font-size: 52px !important;
-          }
-        }
-      `}</style>
     </section>
   );
 }

--- a/src/components/Lately.tsx
+++ b/src/components/Lately.tsx
@@ -2,45 +2,90 @@
 
 import { useTranslations } from "next-intl";
 import FadeIn from "./FadeIn";
+import SectionHeader from "./SectionHeader";
 
-const thoughtKeys = [0, 1, 2];
+const glyphs = ["◐", "⌘", "☕"];
 
 export default function Lately() {
   const t = useTranslations("Lately");
 
   return (
-    <section className="relative py-32">
-      <div className="max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-4">
-            {t("heading")}
-          </h2>
-          <p className="font-[family-name:var(--font-inter)] text-on-surface-variant mb-16 max-w-lg">
-            {t("subheading")}
-          </p>
-        </FadeIn>
+    <section id="now">
+      <SectionHeader
+        idx="04"
+        file="right_now.md"
+        title={t("heading")}
+        lede={t("subheading")}
+      />
 
-        <div className="space-y-6">
-          {thoughtKeys.map((i) => (
-            <FadeIn key={i} delay={i * 120}>
-              <div className="group flex gap-5 p-6 rounded-xl bg-surface-low/50 ghost-border hover:bg-surface-highest/30 transition-colors duration-300">
-                <span className="text-2xl shrink-0 mt-0.5">{t(`thoughts.${i}.emoji`)}</span>
-                <div>
-                  <h3 className="font-[family-name:var(--font-manrope)] text-base font-semibold mb-2 group-hover:text-primary transition-colors">
-                    {t(`thoughts.${i}.title`)}
-                  </h3>
-                  <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                    {t(`thoughts.${i}.description`)}
-                  </p>
-                </div>
+      <FadeIn>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-[18px] px-[28px] pb-[56px]">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="relative overflow-hidden rounded-[4px] p-[26px] pb-[28px] transition-all duration-200 hover:border-line-strong hover:-translate-y-[2px]"
+              style={{
+                background: "var(--bg-2)",
+                border: "1px solid var(--line)",
+              }}
+            >
+              <div
+                className="absolute top-[16px] right-[18px]"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "20px",
+                  color: "var(--accent)",
+                  opacity: 0.6,
+                }}
+              >
+                {glyphs[i]}
               </div>
-            </FadeIn>
+              <div
+                className="flex items-center gap-[10px] mb-[20px]"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  color: "var(--fg-faint)",
+                  letterSpacing: "0.06em",
+                  textTransform: "uppercase",
+                }}
+              >
+                <span
+                  className="w-[7px] h-[7px] rounded-full"
+                  style={{
+                    background: "var(--green)",
+                    boxShadow: "0 0 8px rgba(143,182,123,0.5)",
+                  }}
+                />
+                thread · {String(i + 1).padStart(3, "0")}
+              </div>
+              <h4
+                className="mb-[14px]"
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: "26px",
+                  fontWeight: 400,
+                  letterSpacing: "-0.01em",
+                  lineHeight: 1.15,
+                  textWrap: "balance",
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: t.raw(`thoughts.${i}.title`),
+                }}
+              />
+              <p
+                style={{
+                  color: "var(--fg-dim)",
+                  fontSize: "14px",
+                  lineHeight: 1.6,
+                }}
+              >
+                {t(`thoughts.${i}.description`)}
+              </p>
+            </div>
           ))}
         </div>
-      </div>
+      </FadeIn>
     </section>
   );
 }

--- a/src/components/Lately.tsx
+++ b/src/components/Lately.tsx
@@ -19,7 +19,7 @@ export default function Lately() {
       />
 
       <FadeIn>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-[18px] px-[28px] pb-[56px]">
+        <div className="wrap grid grid-cols-1 lg:grid-cols-3 gap-[18px] pb-[56px]">
           {[0, 1, 2].map((i) => (
             <div
               key={i}

--- a/src/components/Lately.tsx
+++ b/src/components/Lately.tsx
@@ -14,7 +14,7 @@ export default function Lately() {
       <SectionHeader
         idx="04"
         file="right_now.md"
-        title={t("heading")}
+        title={t.raw("heading")}
         lede={t("subheading")}
       />
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,125 +1,128 @@
 "use client";
 
-import { useState } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { routing } from "@/i18n/routing";
 
 export default function Navbar() {
-  const [mobileOpen, setMobileOpen] = useState(false);
   const t = useTranslations("Navbar");
   const locale = useLocale();
 
   const navLinks = [
-    { label: t("work"), href: "#work" },
-    { label: t("services"), href: "#services" },
-    { label: t("experience"), href: "#experience" },
-    { label: t("about"), href: "#about" },
-    { label: t("contact"), href: "#contact" },
+    { label: t("work"), href: "#work", n: "01" },
+    { label: t("services"), href: "#services", n: "02" },
+    { label: t("experience"), href: "#experience", n: "03" },
+    { label: t("about"), href: "#about", n: "04" },
+    { label: t("contact"), href: "#contact", n: "05" },
   ];
 
-  const otherLocale = locale === "en" ? "es" : "en";
-
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-md ghost-border border-t-0 border-l-0 border-r-0">
-      <div className="max-w-7xl mx-auto px-6 h-16 flex items-center justify-between">
-        {/* Logo */}
-        <a href="#" className="text-xl font-bold font-[family-name:var(--font-manrope)]">
-          <span className="gradient-text">JM</span>
-        </a>
-
-        {/* Desktop nav */}
-        <div className="hidden md:flex items-center gap-8">
-          {navLinks.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              className="text-sm font-[family-name:var(--font-inter)] text-on-surface-variant hover:text-primary transition-colors duration-200"
-            >
-              {link.label}
-            </a>
-          ))}
-        </div>
-
-        <div className="hidden md:flex items-center gap-3">
-          {/* Language switcher */}
-          <div className="flex items-center gap-1 text-xs font-[family-name:var(--font-inter)]">
-            {routing.locales.map((loc) => (
-              <a
-                key={loc}
-                href={`/${loc}`}
-                className={`px-2 py-1 rounded transition-colors duration-200 ${
-                  loc === locale
-                    ? "text-primary font-semibold"
-                    : "text-on-surface-variant/50 hover:text-on-surface-variant"
-                }`}
-              >
-                {loc.toUpperCase()}
-              </a>
-            ))}
-          </div>
-
-          {/* CTA */}
-          <a
-            href="#contact"
-            className="gradient-btn text-black text-sm font-semibold font-[family-name:var(--font-inter)] px-5 py-2 rounded-lg hover:opacity-90 transition-opacity"
-          >
-            {t("letsTalk")}
-          </a>
-        </div>
-
-        {/* Mobile toggle */}
-        <button
-          className="md:hidden text-on-surface-variant"
-          onClick={() => setMobileOpen(!mobileOpen)}
-          aria-label="Toggle menu"
+    <nav
+      className="fixed top-[34px] left-0 right-0 z-[49] px-[28px] py-[16px] flex items-center gap-[28px]"
+      style={{
+        background: `linear-gradient(to bottom, rgba(var(--bg-rgb), 0.92), rgba(var(--bg-rgb), 0.6) 70%, transparent)`,
+      }}
+    >
+      <a
+        href="#top"
+        className="flex items-center gap-[10px] no-underline transition-opacity duration-150 hover:opacity-80 group"
+        style={{
+          fontFamily: "var(--mono)",
+          fontWeight: 600,
+          fontSize: "13px",
+          letterSpacing: "0.02em",
+          color: "var(--fg)",
+        }}
+        aria-label="Back to top"
+      >
+        <span
+          className="w-[22px] h-[22px] border inline-flex items-center justify-center group-hover:text-bg"
+          style={{
+            borderColor: "var(--accent)",
+            color: "var(--accent)",
+            fontSize: "10px",
+            fontWeight: 700,
+            letterSpacing: 0,
+            transition: "background 0.15s, color 0.15s",
+          }}
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            {mobileOpen ? (
-              <path d="M6 18L18 6M6 6l12 12" />
-            ) : (
-              <path d="M3 12h18M3 6h18M3 18h18" />
-            )}
-          </svg>
-        </button>
-      </div>
+          JM
+        </span>
+        <span>
+          juan murillo<span style={{ color: "var(--accent)" }}>_</span>
+        </span>
+      </a>
 
-      {/* Mobile menu */}
-      {mobileOpen && (
-        <div className="md:hidden glass border-t border-outline-variant/20 px-6 py-4 space-y-3">
-          {navLinks.map((link) => (
+      <ul className="hidden lg:flex list-none gap-1 ml-[18px]">
+        {navLinks.map((link) => (
+          <li key={link.href}>
             <a
-              key={link.href}
               href={link.href}
-              className="block text-sm font-[family-name:var(--font-inter)] text-on-surface-variant hover:text-primary transition-colors"
-              onClick={() => setMobileOpen(false)}
+              className="flex items-baseline gap-[6px] px-[10px] py-[6px] rounded-[3px] no-underline transition-colors duration-150 hover:bg-bg-3"
+              style={{
+                fontFamily: "var(--mono)",
+                fontSize: "12px",
+                color: "var(--fg-dim)",
+              }}
             >
+              <span
+                style={{
+                  color: "var(--fg-faint)",
+                  fontSize: "10.5px",
+                }}
+              >
+                {link.n}
+              </span>
               {link.label}
             </a>
+          </li>
+        ))}
+      </ul>
+
+      <div className="ml-auto flex items-center gap-[10px]">
+        <div
+          className="inline-flex border rounded-[3px] overflow-hidden"
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "11px",
+            borderColor: "var(--line-strong)",
+          }}
+        >
+          {routing.locales.map((loc) => (
+            <a
+              key={loc}
+              href={`/${loc}`}
+              className="border-0 px-[9px] py-[5px] cursor-pointer no-underline"
+              style={{
+                fontFamily: "inherit",
+                fontSize: "inherit",
+                background:
+                  loc === locale ? "var(--fg)" : "transparent",
+                color:
+                  loc === locale ? "var(--bg)" : "var(--fg-dim)",
+              }}
+            >
+              {loc.toUpperCase()}
+            </a>
           ))}
-          <div className="flex items-center gap-2 py-1">
-            {routing.locales.map((loc) => (
-              <a
-                key={loc}
-                href={`/${loc}`}
-                className={`text-xs font-[family-name:var(--font-inter)] px-2 py-1 rounded transition-colors ${
-                  loc === locale
-                    ? "text-primary font-semibold"
-                    : "text-on-surface-variant/50 hover:text-on-surface-variant"
-                }`}
-              >
-                {loc.toUpperCase()}
-              </a>
-            ))}
-          </div>
-          <a
-            href="#contact"
-            className="block gradient-btn text-black text-sm font-semibold text-center px-5 py-2 rounded-lg"
-            onClick={() => setMobileOpen(false)}
-          >
-            {t("letsTalk")}
-          </a>
         </div>
-      )}
+
+        <a
+          href="#contact"
+          className="inline-flex items-center gap-[8px] rounded-[3px] border-0 cursor-pointer no-underline transition-transform duration-150 hover:-translate-y-px"
+          style={{
+            background: "var(--accent)",
+            color: "var(--bg)",
+            fontFamily: "var(--mono)",
+            fontWeight: 600,
+            fontSize: "12px",
+            padding: "8px 14px",
+            boxShadow: "none",
+          }}
+        >
+          <span style={{ color: "rgba(14,12,10,0.5)" }}>$</span>
+          {t("letsTalk")}
+        </a>
+      </div>
     </nav>
   );
 }

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -18,8 +18,8 @@ export default function SectionHeader({
   return (
     <FadeIn>
       <div
-        className="border-t border-line flex items-baseline gap-[24px] flex-wrap"
-        style={{ padding: "56px 28px 24px" }}
+        className="wrap border-t border-line flex items-baseline gap-6 flex-wrap"
+        style={{ paddingTop: "56px", paddingBottom: "24px" }}
       >
         <span
           style={{
@@ -52,7 +52,7 @@ export default function SectionHeader({
           {file}
         </span>
         <h2
-          className="w-full mt-[8px]"
+          className="w-full mt-2"
           style={{
             fontFamily: "var(--serif)",
             fontWeight: 400,
@@ -66,7 +66,7 @@ export default function SectionHeader({
         />
         {lede && (
           <p
-            className="w-full max-w-[640px] mt-[10px]"
+            className="w-full max-w-[640px] mt-2.5"
             style={{
               color: "var(--fg-dim)",
               fontSize: "15.5px",

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import FadeIn from "./FadeIn";
+
+interface SectionHeaderProps {
+  idx: string;
+  file: string;
+  title: string;
+  lede?: string;
+}
+
+export default function SectionHeader({
+  idx,
+  file,
+  title,
+  lede,
+}: SectionHeaderProps) {
+  return (
+    <FadeIn>
+      <div
+        className="border-t border-line flex items-baseline gap-[24px] flex-wrap"
+        style={{ padding: "56px 28px 24px" }}
+      >
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "11px",
+            color: "var(--fg-faint)",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          // {idx}
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            color: "var(--fg-faint)",
+            fontSize: "12px",
+          }}
+        >
+          ─────────
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--mono)",
+            fontSize: "13px",
+            color: "var(--fg-dim)",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {file}
+        </span>
+        <h2
+          className="w-full mt-[8px]"
+          style={{
+            fontFamily: "var(--serif)",
+            fontWeight: 400,
+            fontSize: "clamp(36px, 5vw, 60px)",
+            lineHeight: 1.05,
+            letterSpacing: "-0.02em",
+            color: "var(--fg)",
+            textWrap: "balance",
+          }}
+          dangerouslySetInnerHTML={{ __html: title }}
+        />
+        {lede && (
+          <p
+            className="w-full max-w-[640px] mt-[10px]"
+            style={{
+              color: "var(--fg-dim)",
+              fontSize: "15.5px",
+              lineHeight: 1.6,
+            }}
+          >
+            {lede}
+          </p>
+        )}
+      </div>
+    </FadeIn>
+  );
+}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -2,39 +2,89 @@
 
 import { useTranslations } from "next-intl";
 import FadeIn from "./FadeIn";
+import SectionHeader from "./SectionHeader";
 
-const capabilityKeys = [0, 1, 2];
+const serviceData = [
+  { ascii: "{ }", num: "01 / full-stack" },
+  { ascii: "</>", num: "02 / ai & automation" },
+  { ascii: "[ ]", num: "03 / leadership" },
+];
 
 export default function Services() {
   const t = useTranslations("Services");
 
   return (
-    <section id="services" className="relative py-32 bg-surface-low">
-      <div className="max-w-4xl mx-auto px-6">
-        <FadeIn>
-          <p className="text-xs font-[family-name:var(--font-inter)] tracking-[0.2em] uppercase text-on-surface-variant mb-4">
-            {t("sectionLabel")}
-          </p>
-          <h2 className="font-[family-name:var(--font-manrope)] text-3xl sm:text-4xl font-bold mb-16">
-            {t("heading")}
-          </h2>
-        </FadeIn>
+    <section id="services">
+      <SectionHeader
+        idx="02"
+        file="what_i_do.md"
+        title={t("heading")}
+        lede={t("subheading")}
+      />
 
-        <div className="space-y-12">
-          {capabilityKeys.map((i) => (
-            <FadeIn key={i} delay={i * 100}>
-              <div className="grid sm:grid-cols-[200px_1fr] gap-4 sm:gap-8">
-                <h3 className="font-[family-name:var(--font-manrope)] text-lg font-bold text-primary">
-                  {t(`capabilities.${i}.title`)}
-                </h3>
-                <p className="font-[family-name:var(--font-inter)] text-sm text-on-surface-variant leading-relaxed">
-                  {t(`capabilities.${i}.description`)}
-                </p>
+      <FadeIn>
+        <div className="grid grid-cols-1 lg:grid-cols-3 border-t border-b border-line">
+          {serviceData.map((svc, i) => (
+            <div
+              key={i}
+              className="px-[28px] py-[36px] pb-[44px] relative transition-colors duration-200 hover:bg-accent/[0.03] border-b lg:border-b-0 lg:border-r border-line last:border-r-0 last:border-b-0"
+            >
+              <div
+                className="mb-[20px]"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "10px",
+                  color: "var(--accent)",
+                  opacity: 0.5,
+                  whiteSpace: "pre",
+                  lineHeight: 1.1,
+                  letterSpacing: 0,
+                }}
+              >
+                {svc.ascii}
               </div>
-            </FadeIn>
+              <div
+                className="flex items-center gap-[10px] mb-[28px]"
+                style={{
+                  fontFamily: "var(--mono)",
+                  fontSize: "11px",
+                  color: "var(--fg-faint)",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                <span
+                  className="inline-block w-[16px] h-[1px]"
+                  style={{ background: "var(--accent)" }}
+                />
+                {svc.num}
+              </div>
+              <h3
+                className="mb-[16px]"
+                style={{
+                  fontFamily: "var(--serif)",
+                  fontSize: "32px",
+                  fontWeight: 400,
+                  letterSpacing: "-0.01em",
+                  lineHeight: 1.1,
+                  textWrap: "balance",
+                }}
+                dangerouslySetInnerHTML={{
+                  __html: t.raw(`capabilities.${i}.title`),
+                }}
+              />
+              <p
+                style={{
+                  color: "var(--fg-dim)",
+                  fontSize: "14.5px",
+                  lineHeight: 1.65,
+                }}
+              >
+                {t(`capabilities.${i}.description`)}
+              </p>
+            </div>
           ))}
         </div>
-      </div>
+      </FadeIn>
     </section>
   );
 }

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -23,7 +23,7 @@ export default function Services() {
       />
 
       <FadeIn>
-        <div className="grid grid-cols-1 lg:grid-cols-3 border-t border-b border-line">
+        <div className="wrap grid grid-cols-1 lg:grid-cols-3 border-t border-b border-line" style={{ padding: 0 }}>
           {serviceData.map((svc, i) => (
             <div
               key={i}

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -18,7 +18,7 @@ export default function Services() {
       <SectionHeader
         idx="02"
         file="what_i_do.md"
-        title={t("heading")}
+        title={t.raw("heading")}
         lede={t("subheading")}
       />
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+export default function StatusBar() {
+  const t = useTranslations("StatusBar");
+  const [uptime, setUptime] = useState("00:00:00");
+  const [coffeeCount, setCoffeeCount] = useState(2);
+
+  useEffect(() => {
+    const start = Date.now() - (7 * 3600 + 23 * 60) * 1000;
+    const tick = () => {
+      const s = Math.floor((Date.now() - start) / 1000);
+      const h = String(Math.floor(s / 3600)).padStart(2, "0");
+      const m = String(Math.floor((s % 3600) / 60)).padStart(2, "0");
+      const ss = String(s % 60).padStart(2, "0");
+      setUptime(`${h}:${m}:${ss}`);
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (Math.random() > 0.85) {
+        setCoffeeCount((prev) => Math.min(prev + 1, 9));
+      }
+    }, 9000);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div
+      className="fixed top-0 left-0 right-0 z-50 h-[34px] flex items-center px-[18px] gap-[18px] border-b border-line"
+      style={{
+        background: `rgba(var(--bg-rgb), 0.85)`,
+        backdropFilter: "blur(14px)",
+        WebkitBackdropFilter: "blur(14px)",
+        fontFamily: "var(--mono)",
+        fontSize: "11.5px",
+        color: "var(--fg-dim)",
+        letterSpacing: "0.01em",
+      }}
+    >
+      <div className="flex items-center">
+        <span
+          className="inline-block w-[7px] h-[7px] rounded-full mr-[6px]"
+          style={{
+            background: "var(--green)",
+            boxShadow: "0 0 6px rgba(143, 182, 123, 0.6)",
+            animation: "pulse 2.4s ease-in-out infinite",
+          }}
+        />
+        {t("deployed")}
+      </div>
+      <span style={{ color: "var(--fg-faint)" }}>|</span>
+      <div className="flex items-center">
+        <span style={{ color: "var(--fg-faint)" }}>{t("branch")}</span>&nbsp;
+        <span style={{ color: "var(--fg)" }}>main</span>
+      </div>
+      <span className="hidden sm:inline" style={{ color: "var(--fg-faint)" }}>|</span>
+      <div className="hidden sm:flex items-center">
+        <span style={{ color: "var(--fg-faint)" }}>{t("uptime")}</span>&nbsp;
+        <span style={{ color: "var(--fg)" }}>{uptime}</span>
+      </div>
+      <span className="hidden md:inline" style={{ color: "var(--fg-faint)" }}>|</span>
+      <div className="hidden md:flex items-center">
+        <span style={{ color: "var(--fg-faint)" }}>{t("loc")}</span>&nbsp;
+        <span style={{ color: "var(--fg)" }}>{t("location")}</span>
+      </div>
+      <div className="ml-auto flex gap-[18px] items-center">
+        <div className="hidden sm:flex items-center">
+          <span style={{ color: "var(--fg-faint)" }}>{t("coffee")}</span>&nbsp;
+          <span style={{ color: "var(--fg)" }}>
+            {coffeeCount} {t("cups")}
+          </span>
+        </div>
+        <div className="hidden sm:flex items-center">
+          <span style={{ color: "var(--fg-faint)" }}>{t("status")}</span>&nbsp;
+          <span style={{ color: "var(--green)" }}>{t("statusValue")}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -81,6 +81,32 @@ export default function StatusBar() {
           <span style={{ color: "var(--fg-faint)" }}>{t("status")}</span>&nbsp;
           <span style={{ color: "var(--green)" }}>{t("statusValue")}</span>
         </div>
+        <span style={{ color: "var(--fg-faint)" }}>│</span>
+        <div className="flex items-center">
+          <span style={{ color: "var(--fg-faint)" }}>{t("press")}</span>&nbsp;
+          <kbd
+            className="cursor-pointer"
+            style={{
+              fontFamily: "inherit",
+              background: "var(--bg-3)",
+              border: "1px solid var(--line-strong)",
+              padding: "1px 6px",
+              borderRadius: "2px",
+              color: "var(--fg)",
+            }}
+            onClick={() => {
+              window.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                  key: "k",
+                  metaKey: true,
+                  bubbles: true,
+                })
+              );
+            }}
+          >
+            ⌘K
+          </kbd>
+        </div>
       </div>
     </div>
   );

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -8,7 +8,8 @@
     "coffee": "coffee",
     "cups": "cups",
     "status": "status",
-    "statusValue": "open to connect"
+    "statusValue": "open to connect",
+    "press": "press"
   },
   "Navbar": {
     "work": "work",
@@ -191,6 +192,7 @@
     "goToNow": "Right now",
     "goToAbout": "About",
     "goToContact": "Contact",
+    "copyMarkdown": "Copy page as Markdown",
     "copyEmail": "Copy email / juanchomurcas@gmail.com",
     "openLinkedIn": "Open LinkedIn",
     "openGitHub": "Open GitHub",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,174 +1,213 @@
 {
+  "StatusBar": {
+    "deployed": "deployed",
+    "branch": "branch",
+    "uptime": "uptime",
+    "loc": "loc",
+    "location": "Bogota · -05 UTC",
+    "coffee": "coffee",
+    "cups": "cups",
+    "status": "status",
+    "statusValue": "open to connect"
+  },
   "Navbar": {
-    "work": "Work",
-    "services": "Services",
-    "experience": "Experience",
-    "about": "About",
-    "contact": "Contact",
-    "letsTalk": "Let's Talk"
+    "work": "work",
+    "services": "services",
+    "experience": "experience",
+    "about": "about",
+    "contact": "contact",
+    "letsTalk": "let's talk"
   },
   "Hero": {
-    "greeting": "Hey, I'm",
-    "name": "Juan Murillo",
-    "basedIn": "based in Bogotá, working globally.",
-    "roles": {
-      "0": "product-minded engineer",
-      "1": "technical lead",
-      "2": "founder",
-      "3": "AI enthusiast",
-      "4": "coffee enthusiast"
+    "statusBadge": "open to connect · Q2 2026",
+    "roleLine": "senior full-stack · technical lead",
+    "headlinePre": "Hey, I'm",
+    "name": "Juan",
+    "headlineMid": "I build",
+    "headlineUnderline": "complex things",
+    "headlineEnd": "with AI, code &",
+    "headlineAccent": "coffee",
+    "basedIn": "Bogota, working globally",
+    "currently": {
+      "0": "'leading AI automation at Snappr'",
+      "1": "'pairing with Claude at 7am'",
+      "2": "'shipping Temporal workflows'",
+      "3": "'brewing the 3rd cup'",
+      "4": "'tuning models with GRPO'"
     },
-    "headlineLine1": "I love complex problems,",
-    "headlineLine2": "cutting-edge tech,",
-    "headlineLine3": "and",
-    "headlineHighlight": "AI.",
-    "bodyParagraph1Start": "At",
-    "bodyAtlassian": "Atlassian",
-    "bodyAtlassianText": ", I built the entire UI for managing custom domains and was a key contributor to closing",
-    "bodyAtlassianTicket": "CLOUD-6999",
-    "bodyAtlassianAfterTicket": ", a ticket open for over a decade. At",
-    "bodySnappr": "Snappr",
-    "bodySnapprText": ", I led the AI automation effort that took food image production from fully manual to 56% automated. At",
-    "bodyGoogle": "Google",
-    "bodyGoogleText": ", I helped optimize the Play Store marketing website.",
-    "bodyParagraph2Start": "Before all that, I co-founded a",
-    "bodyCoffeeStartup": "coffee startup",
-    "bodyParagraph2End": "and earned a Y Combinator interview in under a month.",
-    "ctaWork": "See how I work",
-    "ctaHello": "Say hello"
+    "termTitle": "Senior Full-Stack Engineer & Technical Lead",
+    "termTeams": "led 3-8 engineers, 3 timezones",
+    "ctaWork": "see selected work",
+    "ctaHello": "say hello"
   },
   "FeaturedWork": {
     "sectionLabel": "Selected Work",
-    "heading": "A few projects I'm proud of.",
-    "subheading": "Not just what shipped, but the context, the approach, and what I actually contributed.",
-    "theProblem": "The Problem",
-    "myRole": "My Role",
+    "heading": "A few projects I'm <em>proud of</em>.",
+    "subheading": "Not just what shipped. The context, the approach, and what I actually contributed. I care about owning my slice honestly.",
+    "yearLabel": "year",
+    "roleLabel": "role",
+    "teamLabel": "team",
+    "theProblem": "problem",
+    "myRole": "my role",
     "studies": {
       "0": {
         "company": "Snappr",
-        "period": "2024 - Present",
-        "title": "Leading AI automation for food imagery",
+        "period": "2024 → present",
+        "role": "technical lead",
+        "team": "AI Food · AI Core",
+        "metaLabel": "status",
+        "metaValue": "● shipping",
+        "title": "Leading AI automation for <em>food imagery</em> at global delivery scale.",
         "problem": "Worldwide delivery apps needed thousands of food images. Every image was manually shot, edited, and reviewed. The process didn't scale with demand.",
-        "approach": "As technical lead for the AI Food and AI Core teams, I led the automation pipeline: orchestrating image generation, labeling, and review through Temporal workflows on AWS. I stabilized and maintained the Next.js app that the ops team relies on daily, and coordinated across timezones with Ops and AI engineers.",
+        "approach": "As technical lead for AI Food and AI Core, I led the automation pipeline. Orchestrating image generation, labeling, and review through Temporal workflows on AWS. I stabilized the Next.js app Ops relies on daily, and coordinated across timezones with Ops and AI engineers.",
         "result": "The team went from 0% to 56% automation. I didn't build every piece, but I led the pipeline, kept the system stable, and made sure the parts fit together.",
         "resultLabel": "automated"
       },
       "1": {
         "company": "Atlassian",
-        "period": "2022 - 2024",
-        "title": "Helping close a decade-old ticket",
-        "problem": "Custom domains for Atlassian products needed a full admin UI, secure input handling, and a real-time threat detection system before the feature could ship. The ticket (CLOUD-6999) had been open for over 10 years.",
-        "approach": "I architected the React UI for managing custom domains, with XSS protection and WCAG 2.1 AA accessibility, and led cross-team integration across Atlassian products. I also built the Certificate Transparency Logs monitoring component, an event-driven system in Node.js and Go on AWS Lambda, to detect man-in-the-middle attacks.",
-        "result": "My contributions were key parts of what it took to finally close this ticket. It was a team effort spanning multiple groups. I'm proud of the pieces I owned.",
-        "resultLabel": "ticket closed",
-        "linkLabel": "See the ticket"
+        "period": "2022 → 2024",
+        "role": "technical lead (via EPAM)",
+        "team": "Custom Domains",
+        "metaLabel": "ticket",
+        "metaValue": "CLOUD-6999 · 10+ yrs",
+        "title": "Helping close a <em>decade-old ticket</em>.",
+        "problem": "Custom domains for Atlassian products needed a full admin UI, secure input handling, and real-time threat detection before the feature could ship. The ticket had been open for over ten years.",
+        "approach": "I architected the React UI for managing custom domains, with XSS protection and WCAG 2.1 AA accessibility, and led cross-team integration. I also built the Certificate Transparency Logs monitoring component: an event-driven system in Node.js and Go on AWS Lambda, to detect man-in-the-middle attacks.",
+        "result": "My contributions were key parts of what it took to finally close it. A team effort spanning multiple groups. I'm proud of the pieces I owned.",
+        "resultLabel": "ticket → closed",
+        "linkLabel": "see the ticket"
       },
       "2": {
-        "company": "Arjé Coffee",
-        "period": "2019 - 2021",
-        "title": "From bean to browser in under a month",
+        "company": "Arje Coffee",
+        "period": "2019 → 2021",
+        "role": "CTO · co-founder",
+        "team": "2 founders · 0 → 1",
+        "metaLabel": "outcome",
+        "metaValue": "YC interview",
+        "title": "From <em>bean to browser</em> in under a month.",
         "problem": "We wanted to build a subscription coffee marketplace connecting Colombian farms to global consumers. No team, no product, tight timeline.",
         "approach": "We built the entire tech stack: React frontend, Node.js backend, payment integrations, order management APIs. Automated 66% of manual order review. Launched both the marketplace and the physical product from zero.",
-        "result": "We shipped the MVP in under a month and earned a Y Combinator interview. Building both the product and the tech taught me more about shipping than any job before it.",
+        "result": "Shipped the MVP in under a month and earned a Y Combinator interview. Building both the product and the tech taught me more about shipping than any job before.",
         "resultLabel": "to launch"
       }
     }
   },
   "Services": {
     "sectionLabel": "What I Do",
-    "heading": "I go deep on three things.",
+    "heading": "I go <em>deep</em> on three things.",
+    "subheading": "I'd rather be great at a few things than passable at many. Here's where I tend to make the most impact.",
     "capabilities": {
       "0": {
-        "title": "Full-stack products",
+        "title": "Full-stack <em>products</em>, end-to-end.",
         "description": "Frontend to backend to infra. React, TypeScript, Node.js, Python, PostgreSQL, deployed on AWS or GCP. I like owning the full picture, from the UI someone sees to the pipeline running behind it."
       },
       "1": {
-        "title": "AI & automation",
-        "description": "Production AI agents, fine-tuned models with GRPO, and Temporal workflows that replaced manual pipelines. I enjoy the messy middle: figuring out where AI actually helps vs. where it just adds complexity."
+        "title": "AI & automation that <em>actually ships</em>.",
+        "description": "Production AI agents, fine-tuned models with GRPO, Temporal workflows replacing manual pipelines. I enjoy the messy middle: figuring out where AI actually helps vs. where it just adds complexity."
       },
       "2": {
-        "title": "Leading engineering teams",
-        "description": "I've led teams of 3-8 engineers, run architecture reviews, and mentored across timezones. I care about code quality, but I care more about the team shipping the right thing together."
+        "title": "Leading engineering <em>teams</em>.",
+        "description": "I've led teams of 3-8 engineers, run architecture reviews, and mentored across timezones. I care about code quality, but I care more about the team shipping the right thing, together."
       }
     }
   },
   "Experience": {
     "sectionLabel": "Experience",
-    "heading": "The short version.",
+    "heading": "The <em>short</em> version.",
+    "subheading": "A condensed history. Hover any row to inspect.",
     "timeline": {
       "0": {
         "company": "Snappr",
         "role": "Senior Full-Stack Engineer II",
-        "period": "2024 - Present",
-        "description": "Technical lead for AI Food and AI Core teams. Leading the automation pipeline from 0% to 56%. Coordinating cross-timezone collaboration with Ops and AI teams on AWS."
+        "period": "2024 → now",
+        "description": "Technical lead for AI Food and AI Core. Leading the automation pipeline from 0% to 56%. Coordinating cross-timezone collaboration with Ops and AI teams on AWS."
       },
       "1": {
         "company": "EPAM @ Atlassian",
         "role": "Technical Lead",
-        "period": "2022 - 2024",
+        "period": "2022 → 2024",
         "description": "Key contributor to closing CLOUD-6999. Built the custom domains UI and threat detection monitoring. Managed and mentored a team of 3 engineers."
       },
       "2": {
         "company": "Huge @ Google",
         "role": "Senior Engineer",
-        "period": "2019 - 2022",
-        "description": "Optimized the Google Play marketing website performance. Built CI/CD pipelines. Created a Chrome Extension that reduced missing localizations in production by 30%."
+        "period": "2019 → 2022",
+        "description": "Optimized the Google Play marketing website performance. Built CI/CD pipelines. Shipped a Chrome Extension that reduced missing localizations in production by 30%."
       },
       "3": {
-        "company": "Arjé Coffee",
+        "company": "Arje Coffee",
         "role": "CTO & Co-founder",
-        "period": "2019 - 2021",
+        "period": "2019 → 2021",
         "description": "Built the subscription marketplace from scratch. Automated payments, launched in under a month, earned a Y Combinator interview."
-
       }
     }
   },
   "Lately": {
     "sectionLabel": "Right Now",
-    "heading": "What I'm thinking about",
+    "heading": "What I'm <em>thinking</em> about.",
     "subheading": "A few things I'm exploring, building, or just can't stop talking about.",
     "thoughts": {
       "0": {
-        "emoji": "\ud83e\udde0",
-        "title": "Bridging the technical gap",
-        "description": "Thinking a lot about how the best technology feels invisible. The real challenge isn't building powerful AI tools, it's making them so intuitive that non-technical teams adopt them without a second thought. That's where the biggest impact lives."
+        "title": "Bridging the <em>technical gap</em>.",
+        "description": "The best technology feels invisible. The real challenge isn't building powerful AI tools. It's making them so intuitive that non-technical teams adopt them without a second thought. That's where the biggest impact lives."
       },
       "1": {
-        "emoji": "\u26a1",
-        "title": "Vibe coding with Claude & Cursor",
-        "description": "I've been using AI coding tools daily, not as autocomplete, but as a thinking partner. Codex, Claude CLI, Cursor, Devin. The workflow is changing fast."
+        "title": "Vibe coding with <em>Claude & Cursor</em>.",
+        "description": "I've been using AI coding tools daily, not as autocomplete, but as a thinking partner. Codex, Claude CLI, Cursor, Devin. The workflow is changing fast, and I want to be early."
       },
       "2": {
-        "emoji": "\u2615",
-        "title": "Still obsessed with coffee",
-        "description": "Arjé Coffee taught me more about building products than any job. When you have to ship both the code and the physical product, you learn what actually matters to users."
+        "title": "Still <em>obsessed</em> with coffee.",
+        "description": "Arje taught me more about building products than any job. When you have to ship both the code and the physical product, you learn what actually matters to users."
       }
     }
   },
   "About": {
     "sectionLabel": "About",
-    "heading": "A bit more context.",
-    "paragraph1": "I studied Systems & Computing Engineering at <strong>Universidad de los Andes</strong> in Bogotá. My first real project was Shipyard, an open-source React app built on top of <strong>navio.dev</strong> to help people explore large network visualizations without writing code. That's when I realized the projects I enjoy most are the ones that remove friction for others.",
-    "paragraph2": "That principle stuck. Whether I was building Google Play features used by millions, a security system protecting Atlassian's cloud infrastructure, or an AI pipeline replacing manual workflows at Snappr, I keep coming back to the same question: does this actually make someone's day easier?",
-    "paragraph3": "I've spoken at <strong>JSConf Colombia</strong> twice (2018 & 2023), mentored at Code Your Future, and I still build side projects for fun. I speak English and Spanish natively, and I work best with teams that move fast and care about craft."
+    "heading": "A bit more <em>context</em>.",
+    "location": "Bogota, CO · working globally",
+    "paragraph1": "I studied <em>Systems & Computing Engineering</em> at Universidad de los Andes in Bogota. My first real project was Shipyard, an open-source React app built on top of navio.dev, to help people explore large network visualizations without writing code. That's when I realized the projects I enjoy most are the ones that remove friction for others.",
+    "paragraph2": "That principle stuck. Whether I was building Google Play features used by millions, a security system protecting cloud infrastructure, or an AI pipeline replacing manual workflows, I keep coming back to the same question: <em>does this actually make someone's day easier?</em>",
+    "paragraph3": "I've spoken at JSConf Colombia twice (2018 & 2023), mentored at Code Your Future, and I still build side projects for fun. I speak English and Spanish natively, and I work best with teams that move fast and care about craft."
   },
   "Contact": {
     "sectionLabel": "Contact",
-    "heading": "I'm always up for a good conversation.",
-    "subheading": "Whether it's about technical advisory, speaking at your event, collaborating on something interesting, or just nerding out about coffee and code, just reach out.",
-    "basedIn": "Based in Colombia. Working remotely with global teams"
+    "heading": "I'm always up for a <em>good conversation</em>.",
+    "subheading": "Whether it's about technical advisory, speaking at your event, collaborating on something interesting, or just nerding out about coffee and code. Reach out.",
+    "talkLink": "JSConf Colombia 2023 talk",
+    "cvLink": "/cv · PDF"
   },
   "Footer": {
-    "copyright": "Juan Murillo. Crafted with purpose."
+    "location": "Based in Colombia · working remotely with global teams",
+    "copyright": "Juan Murillo · crafted with purpose & caffeine"
+  },
+  "CommandPalette": {
+    "placeholder": "Jump to section, toggle theme, copy email...",
+    "navigate": "navigate",
+    "actions": "actions",
+    "goToTop": "Go to top",
+    "goToWork": "Work / selected projects",
+    "goToServices": "What I do",
+    "goToExperience": "Experience",
+    "goToNow": "Right now",
+    "goToAbout": "About",
+    "goToContact": "Contact",
+    "copyEmail": "Copy email / juanchomurcas@gmail.com",
+    "openLinkedIn": "Open LinkedIn",
+    "openGitHub": "Open GitHub",
+    "sendEmail": "Send an email",
+    "noResults": "No matches. Try \"work\", \"email\", or \"theme\".",
+    "navLabel": "navigate",
+    "selectLabel": "select",
+    "closeLabel": "close"
   },
   "LanguageSwitcher": {
     "en": "EN",
     "es": "ES"
   },
   "Metadata": {
-    "title": "Juan Murillo | Senior Full-Stack Engineer & Technical Lead",
+    "title": "Juan Murillo · Senior Full-Stack Engineer & Technical Lead",
     "description": "Senior Full-Stack Engineer with 7+ years at Google, Atlassian, and Snappr. I build scalable web apps, AI automation pipelines, and lead engineering teams. React, TypeScript, Python, AWS.",
-    "ogTitle": "Juan Murillo | Senior Full-Stack Engineer & Technical Lead",
+    "ogTitle": "Juan Murillo · Senior Full-Stack Engineer & Technical Lead",
     "ogDescription": "Senior Full-Stack Engineer with 7+ years building at Google, Atlassian, and Snappr. AI automation, cloud architecture, and technical leadership."
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -8,7 +8,8 @@
     "coffee": "cafe",
     "cups": "tazas",
     "status": "estado",
-    "statusValue": "abierto a conectar"
+    "statusValue": "abierto a conectar",
+    "press": "presiona"
   },
   "Navbar": {
     "work": "trabajo",
@@ -191,6 +192,7 @@
     "goToNow": "Ahora mismo",
     "goToAbout": "Sobre mi",
     "goToContact": "Contacto",
+    "copyMarkdown": "Copiar pagina como Markdown",
     "copyEmail": "Copiar email / juanchomurcas@gmail.com",
     "openLinkedIn": "Abrir LinkedIn",
     "openGitHub": "Abrir GitHub",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -1,173 +1,213 @@
 {
+  "StatusBar": {
+    "deployed": "desplegado",
+    "branch": "rama",
+    "uptime": "uptime",
+    "loc": "zona",
+    "location": "Bogota · -05 UTC",
+    "coffee": "cafe",
+    "cups": "tazas",
+    "status": "estado",
+    "statusValue": "abierto a conectar"
+  },
   "Navbar": {
-    "work": "Trabajo",
-    "services": "Servicios",
-    "experience": "Experiencia",
-    "about": "Sobre mí",
-    "contact": "Contacto",
-    "letsTalk": "Hablemos"
+    "work": "trabajo",
+    "services": "servicios",
+    "experience": "experiencia",
+    "about": "sobre mi",
+    "contact": "contacto",
+    "letsTalk": "hablemos"
   },
   "Hero": {
-    "greeting": "Hola, soy",
-    "name": "Juan Murillo",
-    "basedIn": "desde Bogotá, trabajando globalmente.",
-    "roles": {
-      "0": "ingeniero orientado al producto",
-      "1": "líder técnico",
-      "2": "fundador",
-      "3": "entusiasta de la IA",
-      "4": "entusiasta del café"
+    "statusBadge": "abierto a conectar · Q2 2026",
+    "roleLine": "senior full-stack · lider tecnico",
+    "headlinePre": "Hola, soy",
+    "name": "Juan",
+    "headlineMid": "Construyo",
+    "headlineUnderline": "cosas complejas",
+    "headlineEnd": "con IA, codigo y",
+    "headlineAccent": "cafe",
+    "basedIn": "Bogota, trabajando globalmente",
+    "currently": {
+      "0": "'liderando automatizacion con IA en Snappr'",
+      "1": "'programando con Claude a las 7am'",
+      "2": "'lanzando workflows en Temporal'",
+      "3": "'preparando la 3ra taza'",
+      "4": "'ajustando modelos con GRPO'"
     },
-    "headlineLine1": "Me apasionan los problemas complejos,",
-    "headlineLine2": "la tecnología de punta,",
-    "headlineLine3": "y",
-    "headlineHighlight": "la IA.",
-    "bodyParagraph1Start": "En",
-    "bodyAtlassian": "Atlassian",
-    "bodyAtlassianText": ", construí toda la interfaz para gestionar dominios personalizados y fui un contribuidor clave para cerrar",
-    "bodyAtlassianTicket": "CLOUD-6999",
-    "bodyAtlassianAfterTicket": ", un ticket abierto por más de una década. En",
-    "bodySnappr": "Snappr",
-    "bodySnapprText": ", lideré el esfuerzo de automatización con IA que llevó la producción de imágenes de comida de un proceso completamente manual a 56% automatizado. En",
-    "bodyGoogle": "Google",
-    "bodyGoogleText": ", ayudé a optimizar el sitio web de marketing de Play Store.",
-    "bodyParagraph2Start": "Antes de todo eso, cofundé una",
-    "bodyCoffeeStartup": "startup de café",
-    "bodyParagraph2End": "y conseguí una entrevista con Y Combinator en menos de un mes.",
-    "ctaWork": "Mi trabajo",
-    "ctaHello": "Hablemos"
+    "termTitle": "Ingeniero Full-Stack Senior & Lider Tecnico",
+    "termTeams": "liderado 3-8 ingenieros, 3 zonas horarias",
+    "ctaWork": "ver trabajo seleccionado",
+    "ctaHello": "saludar"
   },
   "FeaturedWork": {
     "sectionLabel": "Trabajo Seleccionado",
-    "heading": "Algunos proyectos de los que estoy orgulloso.",
-    "subheading": "No solo lo que se lanzó, sino el contexto, el enfoque y lo que realmente contribuí.",
-    "theProblem": "El Problema",
-    "myRole": "Mi Rol",
+    "heading": "Algunos proyectos de los que estoy <em>orgulloso</em>.",
+    "subheading": "No solo lo que se lanzo. El contexto, el enfoque y lo que realmente contribui. Me importa ser honesto con mi parte.",
+    "yearLabel": "año",
+    "roleLabel": "rol",
+    "teamLabel": "equipo",
+    "theProblem": "problema",
+    "myRole": "mi rol",
     "studies": {
       "0": {
         "company": "Snappr",
-        "period": "2024 - Presente",
-        "title": "Liderando la automatización con IA para imágenes de comida",
-        "problem": "Apps de delivery a nivel mundial necesitaban miles de imágenes de comida. Cada imagen se tomaba, editaba y revisaba manualmente. El proceso no escalaba con la demanda.",
-        "approach": "Como líder técnico de los equipos AI Food y AI Core, lideré el pipeline de automatización: orquestando la generación, etiquetado y revisión de imágenes a través de workflows de Temporal en AWS. Estabilicé y mantuve la app de Next.js que el equipo de operaciones usa a diario, y coordiné entre zonas horarias con los equipos de Ops e IA.",
-        "result": "El equipo pasó de 0% a 56% de automatización. No construí cada pieza, pero lideré el pipeline, mantuve el sistema estable y me aseguré de que las partes encajaran.",
+        "period": "2024 → presente",
+        "role": "lider tecnico",
+        "team": "AI Food · AI Core",
+        "metaLabel": "estado",
+        "metaValue": "● lanzando",
+        "title": "Liderando automatizacion con IA para <em>imagenes de comida</em> a escala global.",
+        "problem": "Apps de delivery a nivel mundial necesitaban miles de imagenes de comida. Cada imagen se tomaba, editaba y revisaba manualmente. El proceso no escalaba con la demanda.",
+        "approach": "Como lider tecnico de AI Food y AI Core, lidere el pipeline de automatizacion. Orquestando generacion, etiquetado y revision de imagenes a traves de workflows de Temporal en AWS. Estabilice la app Next.js que Ops usa a diario, y coordine entre zonas horarias con equipos de Ops e IA.",
+        "result": "El equipo paso de 0% a 56% de automatizacion. No construi cada pieza, pero lidere el pipeline, mantuve el sistema estable y me asegure de que las partes encajaran.",
         "resultLabel": "automatizado"
       },
       "1": {
         "company": "Atlassian",
-        "period": "2022 - 2024",
-        "title": "Ayudando a cerrar un ticket de una década",
-        "problem": "Los dominios personalizados para productos de Atlassian necesitaban una interfaz de administración completa, manejo seguro de entrada de datos y un sistema de detección de amenazas en tiempo real antes de poder lanzar la funcionalidad. El ticket (CLOUD-6999) llevaba abierto más de 10 años.",
-        "approach": "Arquitecté la interfaz React para gestionar dominios personalizados, con protección contra XSS y accesibilidad WCAG 2.1 AA, y lideré la integración entre equipos de productos de Atlassian. También construí el componente de monitoreo de Certificate Transparency Logs, un sistema basado en eventos en Node.js y Go en AWS Lambda, para detectar ataques man-in-the-middle.",
-        "result": "Mis contribuciones fueron partes clave de lo que se necesitó para finalmente cerrar este ticket. Fue un esfuerzo de equipo que abarcó múltiples grupos. Estoy orgulloso de las piezas que lideré.",
-        "resultLabel": "ticket cerrado",
-        "linkLabel": "Ver el ticket"
+        "period": "2022 → 2024",
+        "role": "lider tecnico (via EPAM)",
+        "team": "Custom Domains",
+        "metaLabel": "ticket",
+        "metaValue": "CLOUD-6999 · 10+ años",
+        "title": "Ayudando a cerrar un <em>ticket de una decada</em>.",
+        "problem": "Los dominios personalizados para productos de Atlassian necesitaban una interfaz de administracion completa, manejo seguro de entrada de datos y deteccion de amenazas en tiempo real. El ticket llevaba abierto mas de diez años.",
+        "approach": "Arquitecte la interfaz React para gestionar dominios personalizados, con proteccion XSS y accesibilidad WCAG 2.1 AA, y lidere la integracion entre equipos. Tambien construi el componente de monitoreo de Certificate Transparency Logs: un sistema basado en eventos en Node.js y Go en AWS Lambda, para detectar ataques man-in-the-middle.",
+        "result": "Mis contribuciones fueron partes clave de lo que se necesito para finalmente cerrarlo. Un esfuerzo de equipo que abarco multiples grupos. Estoy orgulloso de las piezas que lidere.",
+        "resultLabel": "ticket → cerrado",
+        "linkLabel": "ver el ticket"
       },
       "2": {
-        "company": "Arjé Coffee",
-        "period": "2019 - 2021",
-        "title": "Del grano al navegador en menos de un mes",
-        "problem": "Queríamos construir un marketplace de suscripción de café conectando fincas colombianas con consumidores globales. Sin equipo, sin producto, plazo ajustado.",
-        "approach": "Construimos todo el stack tecnológico: frontend en React, backend en Node.js, integraciones de pago, APIs de gestión de pedidos. Automatizamos el 66% de la revisión manual de pedidos. Lanzamos tanto el marketplace como el producto físico desde cero.",
-        "result": "Lanzamos el MVP en menos de un mes y conseguimos una entrevista con Y Combinator. Construir tanto el producto como la tecnología me enseñó más sobre lanzar productos que cualquier trabajo anterior.",
+        "company": "Arje Coffee",
+        "period": "2019 → 2021",
+        "role": "CTO · cofundador",
+        "team": "2 fundadores · 0 → 1",
+        "metaLabel": "resultado",
+        "metaValue": "entrevista YC",
+        "title": "Del <em>grano al navegador</em> en menos de un mes.",
+        "problem": "Queriamos construir un marketplace de suscripcion de cafe conectando fincas colombianas con consumidores globales. Sin equipo, sin producto, plazo ajustado.",
+        "approach": "Construimos todo el stack: frontend React, backend Node.js, integraciones de pago, APIs de gestion de pedidos. Automatizamos 66% de la revision manual. Lanzamos el marketplace y el producto fisico desde cero.",
+        "result": "Lanzamos el MVP en menos de un mes y conseguimos una entrevista con Y Combinator. Construir tanto el producto como la tecnologia me enseño mas sobre lanzar productos que cualquier trabajo anterior.",
         "resultLabel": "para lanzar"
       }
     }
   },
   "Services": {
     "sectionLabel": "Lo Que Hago",
-    "heading": "Me especializo en tres cosas.",
+    "heading": "Me especializo en <em>tres</em> cosas.",
+    "subheading": "Prefiero ser excelente en pocas cosas que mediocre en muchas. Aqui es donde suelo tener mas impacto.",
     "capabilities": {
       "0": {
-        "title": "Productos full-stack",
-        "description": "Del frontend al backend a la infraestructura. React, TypeScript, Node.js, Python, PostgreSQL, desplegado en AWS o GCP. Me gusta ser dueño de todo el panorama, desde la interfaz que alguien ve hasta el pipeline que corre detrás."
+        "title": "<em>Productos</em> full-stack, de principio a fin.",
+        "description": "Del frontend al backend a la infra. React, TypeScript, Node.js, Python, PostgreSQL, desplegado en AWS o GCP. Me gusta ser dueno de todo el panorama, desde la interfaz hasta el pipeline que corre detras."
       },
       "1": {
-        "title": "IA y automatización",
-        "description": "Agentes de IA en producción, modelos ajustados con GRPO, y workflows de Temporal que reemplazaron pipelines manuales. Disfruto la parte complicada: descubrir dónde la IA realmente ayuda vs. dónde solo agrega complejidad."
+        "title": "IA y automatizacion que <em>realmente se lanza</em>.",
+        "description": "Agentes de IA en produccion, modelos ajustados con GRPO, workflows de Temporal reemplazando pipelines manuales. Disfruto la parte complicada: descubrir donde la IA realmente ayuda vs. donde solo agrega complejidad."
       },
       "2": {
-        "title": "Liderazgo de equipos de ingeniería",
-        "description": "He liderado equipos de 3 a 8 ingenieros, dirigido revisiones de arquitectura y mentorado entre zonas horarias. Me importa la calidad del código, pero me importa más que el equipo lance lo correcto juntos."
+        "title": "Liderando <em>equipos</em> de ingenieria.",
+        "description": "He liderado equipos de 3-8 ingenieros, dirigido revisiones de arquitectura y mentorado entre zonas horarias. Me importa la calidad del codigo, pero me importa mas que el equipo lance lo correcto, juntos."
       }
     }
   },
   "Experience": {
     "sectionLabel": "Experiencia",
-    "heading": "La versión corta.",
+    "heading": "La version <em>corta</em>.",
+    "subheading": "Una historia condensada. Pasa el cursor sobre cualquier fila para inspeccionar.",
     "timeline": {
       "0": {
         "company": "Snappr",
         "role": "Senior Full-Stack Engineer II",
-        "period": "2024 - Presente",
-        "description": "Líder técnico de los equipos AI Food y AI Core. Liderando el pipeline de automatización de 0% a 56%. Coordinando colaboración entre zonas horarias con equipos de Ops e IA en AWS."
+        "period": "2024 → ahora",
+        "description": "Lider tecnico de AI Food y AI Core. Liderando el pipeline de automatizacion de 0% a 56%. Coordinando colaboracion entre zonas horarias con equipos de Ops e IA en AWS."
       },
       "1": {
         "company": "EPAM @ Atlassian",
-        "role": "Líder Técnico",
-        "period": "2022 - 2024",
-        "description": "Contribuidor clave para cerrar CLOUD-6999. Construí la interfaz de dominios personalizados y el monitoreo de detección de amenazas. Gestioné y mentoré un equipo de 3 ingenieros."
+        "role": "Lider Tecnico",
+        "period": "2022 → 2024",
+        "description": "Contribuidor clave para cerrar CLOUD-6999. Construi la interfaz de dominios personalizados y monitoreo de deteccion de amenazas. Gestione y mentore un equipo de 3 ingenieros."
       },
       "2": {
         "company": "Huge @ Google",
         "role": "Ingeniero Senior",
-        "period": "2019 - 2022",
-        "description": "Optimicé el rendimiento del sitio web de marketing de Google Play. Construí pipelines de CI/CD. Creé una extensión de Chrome que redujo las localizaciones faltantes en producción en un 30%."
+        "period": "2019 → 2022",
+        "description": "Optimice el rendimiento del sitio web de marketing de Google Play. Construi pipelines de CI/CD. Lance una extension de Chrome que redujo localizaciones faltantes en produccion en 30%."
       },
       "3": {
-        "company": "Arjé Coffee",
+        "company": "Arje Coffee",
         "role": "CTO y Cofundador",
-        "period": "2019 - 2021",
-        "description": "Construí el marketplace de suscripción desde cero. Automaticé pagos, lancé en menos de un mes, conseguí una entrevista con Y Combinator."
+        "period": "2019 → 2021",
+        "description": "Construi el marketplace de suscripcion desde cero. Automatice pagos, lance en menos de un mes, consegui una entrevista con Y Combinator."
       }
     }
   },
   "Lately": {
     "sectionLabel": "Ahora Mismo",
-    "heading": "En lo que estoy pensando",
+    "heading": "En lo que estoy <em>pensando</em>.",
     "subheading": "Algunas cosas que estoy explorando, construyendo o de las que no puedo dejar de hablar.",
     "thoughts": {
       "0": {
-        "emoji": "🧠",
-        "title": "Cerrando la brecha técnica",
-        "description": "Pensando mucho en cómo la mejor tecnología se siente invisible. El verdadero desafío no es construir herramientas de IA poderosas, es hacerlas tan intuitivas que los equipos no técnicos las adopten sin pensarlo dos veces. Ahí es donde vive el mayor impacto."
+        "title": "Cerrando la <em>brecha tecnica</em>.",
+        "description": "La mejor tecnologia se siente invisible. El verdadero desafio no es construir herramientas de IA poderosas. Es hacerlas tan intuitivas que los equipos no tecnicos las adopten sin pensarlo. Ahi es donde vive el mayor impacto."
       },
       "1": {
-        "emoji": "⚡",
-        "title": "Programando con Claude y Cursor",
-        "description": "He estado usando herramientas de IA para programar a diario, no como autocompletado, sino como compañero de pensamiento. Codex, Claude CLI, Cursor, Devin. El flujo de trabajo está cambiando rápido."
+        "title": "Programando con <em>Claude y Cursor</em>.",
+        "description": "He estado usando herramientas de IA para programar a diario, no como autocompletado, sino como companero de pensamiento. Codex, Claude CLI, Cursor, Devin. El flujo de trabajo esta cambiando rapido."
       },
       "2": {
-        "emoji": "☕",
-        "title": "Sigo obsesionado con el café",
-        "description": "Arjé Coffee me enseñó más sobre construir productos que cualquier trabajo. Cuando tienes que lanzar tanto el código como el producto físico, aprendes lo que realmente le importa a los usuarios."
+        "title": "Sigo <em>obsesionado</em> con el cafe.",
+        "description": "Arje me enseno mas sobre construir productos que cualquier trabajo. Cuando tienes que lanzar tanto el codigo como el producto fisico, aprendes lo que realmente le importa a los usuarios."
       }
     }
   },
   "About": {
-    "sectionLabel": "Sobre Mí",
-    "heading": "Un poco más de contexto.",
-    "paragraph1": "Estudié Ingeniería de Sistemas y Computación en la <strong>Universidad de los Andes</strong> en Bogotá. Mi primer proyecto real fue Shipyard, una app React de código abierto construida sobre <strong>navio.dev</strong> para que cualquier persona pudiera explorar visualizaciones de redes grandes sin escribir código. Ahí me di cuenta de que los proyectos que más disfruto son los que le quitan fricción a los demás.",
-    "paragraph2": "Ese principio se quedó conmigo. Ya sea construyendo funcionalidades de Google Play usadas por millones, un sistema de seguridad protegiendo la infraestructura cloud de Atlassian, o un pipeline de IA reemplazando flujos de trabajo manuales en Snappr, siempre vuelvo a la misma pregunta: ¿esto realmente le facilita el día a alguien?",
-    "paragraph3": "He hablado en <strong>JSConf Colombia</strong> dos veces (2018 y 2023), he sido mentor en Code Your Future, y sigo construyendo proyectos por diversión. Hablo inglés y español de forma nativa, y trabajo mejor con equipos que se mueven rápido y les importa la calidad."
+    "sectionLabel": "Sobre Mi",
+    "heading": "Un poco mas de <em>contexto</em>.",
+    "location": "Bogota, CO · trabajando globalmente",
+    "paragraph1": "Estudie <em>Ingenieria de Sistemas y Computacion</em> en la Universidad de los Andes en Bogota. Mi primer proyecto real fue Shipyard, una app React de codigo abierto construida sobre navio.dev, para que cualquier persona pudiera explorar visualizaciones de redes grandes sin escribir codigo. Ahi me di cuenta de que los proyectos que mas disfruto son los que le quitan friccion a los demas.",
+    "paragraph2": "Ese principio se quedo conmigo. Ya sea construyendo funcionalidades de Google Play usadas por millones, un sistema de seguridad protegiendo infraestructura cloud, o un pipeline de IA reemplazando flujos manuales, siempre vuelvo a la misma pregunta: <em>¿esto realmente le facilita el dia a alguien?</em>",
+    "paragraph3": "He hablado en JSConf Colombia dos veces (2018 y 2023), he sido mentor en Code Your Future, y sigo construyendo proyectos por diversion. Hablo ingles y español de forma nativa, y trabajo mejor con equipos que se mueven rapido y les importa la calidad."
   },
   "Contact": {
     "sectionLabel": "Contacto",
-    "heading": "Siempre estoy abierto a una buena conversación.",
-    "subheading": "Ya sea sobre asesoría técnica, hablar en tu evento, colaborar en algo interesante, o simplemente hablar de café y código, escríbeme.",
-    "basedIn": "Desde Colombia. Trabajando remotamente con equipos globales"
+    "heading": "Siempre estoy abierto a una <em>buena conversacion</em>.",
+    "subheading": "Ya sea sobre asesoria tecnica, hablar en tu evento, colaborar en algo interesante, o simplemente hablar de cafe y codigo. Escribeme.",
+    "talkLink": "Charla JSConf Colombia 2023",
+    "cvLink": "/cv · PDF"
   },
   "Footer": {
-    "copyright": "Juan Murillo. Hecho con propósito."
+    "location": "Desde Colombia · trabajando remotamente con equipos globales",
+    "copyright": "Juan Murillo · hecho con proposito y cafeina"
+  },
+  "CommandPalette": {
+    "placeholder": "Ir a seccion, cambiar tema, copiar email...",
+    "navigate": "navegar",
+    "actions": "acciones",
+    "goToTop": "Ir al inicio",
+    "goToWork": "Trabajo / proyectos seleccionados",
+    "goToServices": "Lo que hago",
+    "goToExperience": "Experiencia",
+    "goToNow": "Ahora mismo",
+    "goToAbout": "Sobre mi",
+    "goToContact": "Contacto",
+    "copyEmail": "Copiar email / juanchomurcas@gmail.com",
+    "openLinkedIn": "Abrir LinkedIn",
+    "openGitHub": "Abrir GitHub",
+    "sendEmail": "Enviar un email",
+    "noResults": "Sin resultados. Prueba \"trabajo\", \"email\" o \"tema\".",
+    "navLabel": "navegar",
+    "selectLabel": "seleccionar",
+    "closeLabel": "cerrar"
   },
   "LanguageSwitcher": {
     "en": "EN",
     "es": "ES"
   },
   "Metadata": {
-    "title": "Juan Murillo | Ingeniero Full-Stack Senior & Líder Técnico",
-    "description": "Ingeniero Full-Stack Senior con más de 7 años en Google, Atlassian y Snappr. Desarrollo de apps web escalables, pipelines de automatización con IA y liderazgo de equipos de ingeniería. React, TypeScript, Python, AWS.",
-    "ogTitle": "Juan Murillo | Ingeniero Full-Stack Senior & Líder Técnico",
-    "ogDescription": "Ingeniero Full-Stack Senior con más de 7 años construyendo en Google, Atlassian y Snappr. Automatización con IA, arquitectura cloud y liderazgo técnico."
+    "title": "Juan Murillo · Ingeniero Full-Stack Senior & Lider Tecnico",
+    "description": "Ingeniero Full-Stack Senior con mas de 7 años en Google, Atlassian y Snappr. Desarrollo de apps web escalables, pipelines de automatizacion con IA y liderazgo de equipos de ingenieria. React, TypeScript, Python, AWS.",
+    "ogTitle": "Juan Murillo · Ingeniero Full-Stack Senior & Lider Tecnico",
+    "ogDescription": "Ingeniero Full-Stack Senior con mas de 7 años construyendo en Google, Atlassian y Snappr. Automatizacion con IA, arquitectura cloud y liderazgo tecnico."
   }
 }


### PR DESCRIPTION
## Summary
- Complete visual redesign from purple/cyan to a terminal/IDE-inspired aesthetic with warm coffee tones (amber accent, dark ink background)
- New typography: JetBrains Mono (code/structure), Instrument Serif (display/headings), Inter (body)
- Added interactive features: StatusBar with live uptime + coffee counter, Command Palette (Cmd+K), typing animation hero with terminal card
- Projects displayed as inspectable code commits with line numbers, services in 3-column grid with ASCII glyphs, experience as monospace grid rows
- Updated both EN and ES translations with new content structure

## Test plan
- [ ] Verify desktop layout renders correctly (hero grid, terminal card, 3-col services)
- [ ] Verify mobile/responsive layout (single column, hidden nav links, adjusted sizes)
- [ ] Test Command Palette opens with Cmd+K or /
- [ ] Test typing animation cycles through items in hero
- [ ] Verify status bar uptime clock and coffee counter increment
- [ ] Test language switcher (EN/ES) with new translation keys
- [ ] Verify smooth scroll navigation from nav links
- [ ] Check film grain overlay is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)